### PR TITLE
Add CLI with Click and Kibana upload functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ help:
 	@echo "  test          - Run unit tests"
 	@echo "  test-smoke    - Run smoke tests"
 
+	@echo "Dashboard Compilation:"
+	@echo "  compile       - Compile YAML dashboards to NDJSON"
+	@echo "  upload        - Compile and upload dashboards to Kibana"
+
 	@echo "Cleaning:"
 	@echo "  clean-full    - Clean up all including virtual environment"
 	@echo "  - clean       - Clean up cache and temporary files"
@@ -84,3 +88,11 @@ setup:
 update-deps:
 	@echo "Updating dependencies..."
 	./.venv/bin/poetry update
+
+compile:
+	@echo "Compiling dashboards..."
+	uv run kb-dashboard compile
+
+upload:
+	@echo "Compiling and uploading dashboards to Kibana..."
+	uv run kb-dashboard compile --upload

--- a/dashboard_compiler/cli.py
+++ b/dashboard_compiler/cli.py
@@ -1,0 +1,281 @@
+"""Command-line interface for the dashboard compiler."""
+
+import asyncio
+import logging
+import sys
+import webbrowser
+from pathlib import Path
+
+import click
+
+from dashboard_compiler.dashboard_compiler import load, render
+from dashboard_compiler.kibana_client import KibanaClient
+
+logger = logging.getLogger(__name__)
+
+# Set up basic logging
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+# Get project root (parent of dashboard_compiler)
+project_root = Path(__file__).parent.parent
+
+DEFAULT_INPUT_DIR = project_root / 'inputs'
+DEFAULT_SCENARIO_DIR = project_root / 'tests/dashboards/scenarios'
+DEFAULT_OUTPUT_DIR = project_root / 'output'
+
+
+def write_ndjson(output_path: Path, lines: list[str], overwrite: bool = True) -> None:
+    """Write a list of JSON strings to an NDJSON file.
+
+    Args:
+        output_path: Path to the output NDJSON file.
+        lines: List of JSON strings to write.
+        overwrite: Whether to overwrite the output file if it exists.
+
+    """
+    if overwrite and output_path.exists():
+        output_path.unlink()
+
+    with output_path.open('w') as f:
+        for line in lines:
+            f.write(line + '\n')
+
+
+def compile_yaml_to_json(yaml_path: Path) -> str | None:
+    """Compile a dashboard YAML to a JSON string for NDJSON.
+
+    Args:
+        yaml_path: Path to the dashboard YAML configuration file.
+
+    Returns:
+        The JSON string for the NDJSON line, or None if compilation fails.
+
+    """
+    try:
+        click.echo(f'Compiling: {yaml_path.relative_to(project_root)}')
+        dashboard_model = load(str(yaml_path))
+        dashboard_kbn_model = render(dashboard_model)
+        return dashboard_kbn_model.model_dump_json(by_alias=True)
+    except FileNotFoundError:
+        click.echo(f'Error: YAML file not found: {yaml_path}', err=True)
+        return None
+    except (ValueError, TypeError, KeyError) as e:
+        click.echo(f'Error compiling {yaml_path}: {e}', err=True)
+        return None
+
+
+def get_yaml_files(directory: Path) -> list[Path]:
+    """Get all YAML files from a directory recursively.
+
+    Args:
+        directory: Directory to search for YAML files.
+
+    Returns:
+        List of Path objects pointing to YAML files.
+
+    """
+    if not directory.is_dir():
+        click.echo(f'Error: Directory not found: {directory}', err=True)
+        sys.exit(1)
+
+    yaml_files = sorted(directory.rglob('*.yaml'))
+
+    if not yaml_files:
+        click.echo(f'Warning: No YAML files found in {directory}', err=True)
+
+    return yaml_files
+
+
+@click.group()
+@click.version_option(version='0.1.0')
+def cli() -> None:
+    """Kibana Dashboard Compiler - Compile YAML dashboards to Kibana format."""
+
+
+@cli.command('compile')
+@click.option(
+    '--input-dir',
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=DEFAULT_SCENARIO_DIR,
+    help='Directory containing YAML dashboard files',
+)
+@click.option(
+    '--output-dir',
+    type=click.Path(file_okay=False, path_type=Path),
+    default=DEFAULT_OUTPUT_DIR,
+    help='Directory to write compiled NDJSON files',
+)
+@click.option(
+    '--output-file',
+    type=str,
+    default='compiled_dashboards.ndjson',
+    help='Name of the combined output NDJSON file',
+)
+@click.option(
+    '--upload',
+    is_flag=True,
+    help='Upload compiled dashboards to Kibana after compilation',
+)
+@click.option(
+    '--kibana-url',
+    type=str,
+    envvar='KIBANA_URL',
+    default='http://localhost:5601',
+    help='Kibana base URL (can also set KIBANA_URL env var)',
+)
+@click.option(
+    '--kibana-username',
+    type=str,
+    envvar='KIBANA_USERNAME',
+    help='Kibana username for basic auth (can also set KIBANA_USERNAME env var)',
+)
+@click.option(
+    '--kibana-password',
+    type=str,
+    envvar='KIBANA_PASSWORD',
+    help='Kibana password for basic auth (can also set KIBANA_PASSWORD env var)',
+)
+@click.option(
+    '--kibana-api-key',
+    type=str,
+    envvar='KIBANA_API_KEY',
+    help='Kibana API key for authentication (can also set KIBANA_API_KEY env var)',
+)
+@click.option(
+    '--no-browser',
+    is_flag=True,
+    help='Do not open browser after upload',
+)
+@click.option(
+    '--overwrite/--no-overwrite',
+    default=True,
+    help='Overwrite existing dashboards in Kibana',
+)
+def compile_dashboards(  # noqa: PLR0913
+    input_dir: Path,
+    output_dir: Path,
+    output_file: str,
+    upload: bool,
+    kibana_url: str,
+    kibana_username: str | None,
+    kibana_password: str | None,
+    kibana_api_key: str | None,
+    no_browser: bool,
+    overwrite: bool,
+) -> None:
+    """Compile YAML dashboard configurations to NDJSON format.
+
+    This command finds all YAML files in the input directory, compiles them
+    to Kibana's JSON format, and outputs them as NDJSON files.
+
+    Optionally, you can upload the compiled dashboards directly to Kibana
+    using the --upload flag.
+    """
+    # Create output directory
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get all YAML files
+    yaml_files = get_yaml_files(input_dir)
+    if not yaml_files:
+        click.echo('No YAML files to compile.')
+        return
+
+    # Compile all files
+    ndjson_lines = []
+    for yaml_file in yaml_files:
+        compiled_json = compile_yaml_to_json(yaml_file)
+        if compiled_json:
+            # Write individual file
+            filename = yaml_file.parent.stem
+            individual_file = output_dir / f'{filename}.ndjson'
+            write_ndjson(individual_file, [compiled_json], overwrite=True)
+            click.echo(f'  ✓ Wrote: {individual_file.relative_to(project_root)}')
+            ndjson_lines.append(compiled_json)
+
+    if not ndjson_lines:
+        click.echo('No valid YAML configurations found or compiled.', err=True)
+        return
+
+    # Write combined file
+    combined_file = output_dir / output_file
+    write_ndjson(combined_file, ndjson_lines, overwrite=True)
+    click.echo(f'\n✓ Compiled {len(ndjson_lines)} dashboard(s) to: {combined_file.relative_to(project_root)}')
+
+    # Upload to Kibana if requested
+    if upload:
+        click.echo(f'\n📤 Uploading to Kibana at {kibana_url}...')
+        asyncio.run(
+            upload_to_kibana(
+                combined_file,
+                kibana_url,
+                kibana_username,
+                kibana_password,
+                kibana_api_key,
+                overwrite,
+                not no_browser,
+            )
+        )
+
+
+async def upload_to_kibana(
+    ndjson_file: Path,
+    kibana_url: str,
+    username: str | None,
+    password: str | None,
+    api_key: str | None,
+    overwrite: bool,
+    open_browser: bool,
+) -> None:
+    """Upload NDJSON file to Kibana.
+
+    Args:
+        ndjson_file: Path to NDJSON file to upload
+        kibana_url: Kibana base URL
+        username: Basic auth username
+        password: Basic auth password
+        api_key: API key for authentication
+        overwrite: Whether to overwrite existing objects
+        open_browser: Whether to open browser after successful upload
+
+    """
+    client = KibanaClient(
+        url=kibana_url,
+        username=username,
+        password=password,
+        api_key=api_key,
+    )
+
+    try:
+        result = await client.upload_ndjson(ndjson_file, overwrite=overwrite)
+
+        if result.get('success'):
+            success_count = result.get('successCount', 0)
+            click.echo(f'✓ Successfully uploaded {success_count} object(s) to Kibana')
+
+            # Extract dashboard IDs
+            dashboard_ids = [obj['id'] for obj in result.get('successResults', []) if obj.get('type') == 'dashboard']
+
+            if dashboard_ids and open_browser:
+                dashboard_url = client.get_dashboard_url(dashboard_ids[0])
+                click.echo(f'🌐 Opening dashboard: {dashboard_url}')
+                webbrowser.open_new_tab(dashboard_url)
+
+            # Show errors if any
+            if result.get('errors'):
+                click.echo(f'\n⚠ Encountered {len(result["errors"])} error(s):', err=True)
+                for error in result['errors']:
+                    click.echo(f'  - {error.get("error", {}).get("message", error)}', err=True)
+        else:
+            click.echo('✗ Upload failed', err=True)
+            if result.get('errors'):
+                for error in result['errors']:
+                    click.echo(f'  - {error.get("error", {}).get("message", error)}', err=True)
+            sys.exit(1)
+
+    except (OSError, ValueError) as e:
+        click.echo(f'✗ Error uploading to Kibana: {e}', err=True)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    cli()

--- a/dashboard_compiler/kibana_client.py
+++ b/dashboard_compiler/kibana_client.py
@@ -1,0 +1,85 @@
+"""Kibana client for uploading dashboards via the Saved Objects API."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class KibanaClient:
+    """Client for interacting with Kibana's Saved Objects API."""
+
+    def __init__(
+        self,
+        url: str,
+        username: str | None = None,
+        password: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        """Initialize the Kibana client.
+
+        Args:
+            url: Base Kibana URL (e.g., http://localhost:5601)
+            username: Basic auth username (optional)
+            password: Basic auth password (optional)
+            api_key: API key for authentication (optional)
+
+        """
+        self.url = url.rstrip('/')
+        self.username = username
+        self.password = password
+        self.api_key = api_key
+
+    async def upload_ndjson(
+        self,
+        ndjson_path: Path,
+        overwrite: bool = True,
+    ) -> dict[str, Any]:
+        """Upload an NDJSON file to Kibana using the Saved Objects Import API.
+
+        Args:
+            ndjson_path: Path to the NDJSON file containing saved objects
+            overwrite: Whether to overwrite existing objects with the same IDs
+
+        Returns:
+            Response dict from Kibana API containing success status and results
+
+        Raises:
+            aiohttp.ClientError: If the request fails
+
+        """
+        endpoint = f'{self.url}/api/saved_objects/_import'
+        if overwrite:
+            endpoint += '?overwrite=true'
+
+        headers = {'kbn-xsrf': 'true'}
+        if self.api_key:
+            headers['Authorization'] = f'ApiKey {self.api_key}'
+
+        auth = None
+        if self.username and self.password:
+            auth = aiohttp.BasicAuth(self.username, self.password)
+
+        async with aiohttp.ClientSession() as session:
+            with ndjson_path.open('rb') as f:
+                data = aiohttp.FormData()
+                data.add_field('file', f, filename=ndjson_path.name, content_type='application/ndjson')
+
+                async with session.post(endpoint, data=data, headers=headers, auth=auth) as response:
+                    response.raise_for_status()
+                    return await response.json()
+
+    def get_dashboard_url(self, dashboard_id: str) -> str:
+        """Get the URL for a specific dashboard.
+
+        Args:
+            dashboard_id: The ID of the dashboard
+
+        Returns:
+            Full URL to the dashboard in Kibana
+
+        """
+        return f'{self.url}/app/dashboards#{dashboard_id}'

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,218 @@
+# Dashboard Compiler CLI
+
+The `kb-dashboard` CLI tool allows you to compile YAML dashboard configurations to Kibana's NDJSON format and optionally upload them directly to Kibana.
+
+## Installation
+
+After installing the project dependencies, the CLI will be available:
+
+```bash
+# Using poetry
+poetry install
+
+# Using uv
+uv sync
+```
+
+## Basic Usage
+
+### Compile Dashboards
+
+Compile YAML dashboards to NDJSON format:
+
+```bash
+kb-dashboard compile
+```
+
+This will:
+- Find all YAML files in `tests/dashboards/scenarios/` (by default)
+- Compile them to Kibana JSON format
+- Output NDJSON files to `output/` directory
+- Create individual NDJSON files per scenario
+- Create a combined `compiled_dashboards.ndjson` file
+
+### Compile and Upload to Kibana
+
+Compile dashboards and upload them directly to Kibana:
+
+```bash
+kb-dashboard compile --upload
+```
+
+This will compile the dashboards and upload them to a local Kibana instance.
+
+## Configuration
+
+### Environment Variables
+
+The CLI supports configuration via environment variables:
+
+```bash
+export KIBANA_URL=http://localhost:5601
+export KIBANA_USERNAME=elastic
+export KIBANA_PASSWORD=changeme
+# OR use API key instead
+export KIBANA_API_KEY=your-api-key-here
+```
+
+Then simply run:
+
+```bash
+kb-dashboard compile --upload
+```
+
+### Command-Line Options
+
+All options can also be specified on the command line:
+
+```bash
+kb-dashboard compile \
+  --upload \
+  --kibana-url http://localhost:5601 \
+  --kibana-username elastic \
+  --kibana-password changeme
+```
+
+## Full Command Reference
+
+### `kb-dashboard compile`
+
+Compile YAML dashboard configurations to NDJSON format.
+
+**Options:**
+
+- `--input-dir PATH` - Directory containing YAML dashboard files (default: `tests/dashboards/scenarios/`)
+- `--output-dir PATH` - Directory to write compiled NDJSON files (default: `output/`)
+- `--output-file NAME` - Name of the combined output NDJSON file (default: `compiled_dashboards.ndjson`)
+- `--upload` - Upload compiled dashboards to Kibana after compilation
+- `--kibana-url URL` - Kibana base URL (default: `http://localhost:5601`, can use `KIBANA_URL` env var)
+- `--kibana-username USER` - Kibana username for basic auth (can use `KIBANA_USERNAME` env var)
+- `--kibana-password PASS` - Kibana password for basic auth (can use `KIBANA_PASSWORD` env var)
+- `--kibana-api-key KEY` - Kibana API key for authentication (can use `KIBANA_API_KEY` env var)
+- `--no-browser` - Do not open browser after upload
+- `--overwrite/--no-overwrite` - Overwrite existing dashboards in Kibana (default: `--overwrite`)
+
+## Examples
+
+### Compile only
+
+```bash
+kb-dashboard compile
+```
+
+### Compile and upload with basic auth
+
+```bash
+kb-dashboard compile \
+  --upload \
+  --kibana-url https://kibana.example.com \
+  --kibana-username admin \
+  --kibana-password secret
+```
+
+### Compile and upload with API key
+
+```bash
+kb-dashboard compile \
+  --upload \
+  --kibana-url https://kibana.example.com \
+  --kibana-api-key "VnVhQm5Yb0JDZGJrUW0tZTVoT3k6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
+```
+
+### Custom input and output directories
+
+```bash
+kb-dashboard compile \
+  --input-dir ./my-dashboards \
+  --output-dir ./compiled \
+  --output-file my-dashboards.ndjson
+```
+
+### Upload without opening browser
+
+```bash
+kb-dashboard compile \
+  --upload \
+  --no-browser
+```
+
+## Makefile Shortcuts
+
+The project includes convenient Makefile targets:
+
+```bash
+# Compile only
+make compile
+
+# Compile and upload (uses environment variables for Kibana config)
+make upload
+```
+
+## Authentication
+
+The CLI supports two authentication methods:
+
+### Basic Authentication
+
+Use username and password:
+
+```bash
+kb-dashboard compile \
+  --upload \
+  --kibana-username elastic \
+  --kibana-password changeme
+```
+
+Or via environment variables:
+
+```bash
+export KIBANA_USERNAME=elastic
+export KIBANA_PASSWORD=changeme
+kb-dashboard compile --upload
+```
+
+### API Key Authentication
+
+Use a Kibana API key:
+
+```bash
+kb-dashboard compile \
+  --upload \
+  --kibana-api-key "your-base64-encoded-key"
+```
+
+Or via environment variable:
+
+```bash
+export KIBANA_API_KEY="your-base64-encoded-key"
+kb-dashboard compile --upload
+```
+
+To create an API key in Kibana:
+1. Go to Stack Management → API Keys
+2. Click "Create API key"
+3. Give it a name and set appropriate privileges
+4. Copy the encoded key and use it with the CLI
+
+## Troubleshooting
+
+### Connection Refused
+
+If you get a connection refused error:
+- Verify Kibana is running: `curl http://localhost:5601/api/status`
+- Check the Kibana URL is correct
+- Ensure there are no firewall rules blocking the connection
+
+### Authentication Failed
+
+If you get authentication errors:
+- Verify your credentials are correct
+- Check that the user has appropriate permissions
+- For API keys, ensure the key hasn't expired
+
+### Upload Errors
+
+If objects fail to upload:
+- Check the Kibana logs for detailed error messages
+- Verify the NDJSON format is valid
+- Use `--no-overwrite` if you want to preserve existing objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ readme = "README.md" # Optional: Add a README later if you wish
 license = "MIT" # Using MIT as a common default, change if needed
 packages = [{include = "dashboard_compiler"}]
 
+[tool.poetry.scripts]
+kb-dashboard = "dashboard_compiler.cli:cli"
+
 [tool.poetry.dependencies]
 python = ">=3.12"
 pyyaml = ">=6.0"
@@ -18,6 +21,8 @@ ruff = ">=0.11.6"
 pytest-asyncio = ">=0.26.0"
 beartype = "^0.20.2"
 humanize = "^4.12.3"
+click = ">=8.1.0"
+aiohttp = ">=3.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Implements a CLI application for the dashboard compiler with integrated Kibana upload functionality.

## Changes

- Add `click` and `aiohttp` dependencies
- Create `KibanaClient` using aiohttp for async HTTP operations
- Create CLI with `kb-dashboard` command
- Implement `compile` command with `--upload` flag
- Support environment variables for Kibana configuration
- Add Makefile targets for `compile` and `upload`
- Add comprehensive CLI documentation

## Usage

```bash
# Compile only
kb-dashboard compile

# Compile and upload
kb-dashboard compile --upload

# Using environment variables
export KIBANA_URL=http://localhost:5601
export KIBANA_USERNAME=elastic
export KIBANA_PASSWORD=changeme
kb-dashboard compile --upload
```

Fixes #28

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20389524908) | [View branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-28-20251220-0503