### PR TITLE
refactor(basedpyright): switch type checker config from pyright to basedpyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ classmethod-decorators = ["classmethod", "pydantic.validator"]
 max-args = 8
 max-statements = 50
 
-[tool.pyright]
+[tool.basedpyright]
 pythonVersion = "3.12"
 typeCheckingMode = "basic"  # Start with basic, increase to strict later
 reportExplicitAny = false


### PR DESCRIPTION
### Summary
Switch type checking from pyright to basedpyright by renaming the config section in pyproject.toml and preserving existing settings. No functional changes; this updates the project to use basedpyright for type checking.

### Details
- Renames configuration section [tool.pyright] to [tool.basedpyright] in pyproject.toml
- Preserves all existing options (pythonVersion, typeCheckingMode, reportExplicitAny, reportMissingTypeStubs, include, exclude)
- No code changes; no breaking changes; ensures compatibility with basedpyright
