### PR TITLE
feat: use abstract types (Sequence, Mapping) for function parameters

### DIFF
--- a/src/dashboard_compiler/controls/compile.py
+++ b/src/dashboard_compiler/controls/compile.py
@@ -1,6 +1,7 @@
 """Compile Control configurations into Kibana view models."""
 
 import uuid
+from collections.abc import Sequence
 
 from dashboard_compiler.controls import ControlTypes
 from dashboard_compiler.controls.config import ControlSettings, MatchTechnique, OptionsListControl, RangeSliderControl, TimeSliderControl
@@ -136,11 +137,11 @@ def compile_control(order: int, control: ControlTypes) -> KbnControlTypes:
     raise NotImplementedError(msg)
 
 
-def compile_control_panels_json(controls: list[ControlTypes]) -> KbnControlPanelsJson:
+def compile_control_panels_json(controls: Sequence[ControlTypes]) -> KbnControlPanelsJson:
     """Compile the control group input for a Dashboard object into its Kibana view model representation.
 
     Args:
-        controls (list[ControlTypes]): The list of control objects to compile.
+        controls (Sequence[ControlTypes]): The sequence of control objects to compile.
 
     Returns:
         KbnControlPanelsJson: The compiled Kibana control panels JSON view model.
@@ -158,12 +159,12 @@ def compile_control_panels_json(controls: list[ControlTypes]) -> KbnControlPanel
     return kbn_control_panels_json
 
 
-def compile_control_group(control_settings: ControlSettings, controls: list[ControlTypes]) -> KbnControlGroupInput:
-    """Compile a control group from a list of ControlTypes into a Kibana view model.
+def compile_control_group(control_settings: ControlSettings, controls: Sequence[ControlTypes]) -> KbnControlGroupInput:
+    """Compile a control group from a sequence of ControlTypes into a Kibana view model.
 
     Args:
         control_settings (ControlSettings): The settings for the control group.
-        controls (list[ControlTypes]): The list of control configurations to compile.
+        controls (Sequence[ControlTypes]): The sequence of control configurations to compile.
 
     Returns:
         KbnControlGroupInput: The compiled Kibana control group input view model.

--- a/src/dashboard_compiler/filters/compile.py
+++ b/src/dashboard_compiler/filters/compile.py
@@ -1,5 +1,7 @@
 """Compile Dashboard filter objects into their Kibana view model representations."""
 
+from collections.abc import Sequence
+
 from dashboard_compiler.filters import (
     AndFilter,
     CustomFilter,
@@ -237,11 +239,11 @@ def compile_filter(*, filter: FilterTypes, negate: bool = False, nested: bool = 
     raise NotImplementedError(msg)
 
 
-def compile_filters(*, filters: list[FilterTypes]) -> list[KbnFilter]:
+def compile_filters(*, filters: Sequence[FilterTypes]) -> list[KbnFilter]:
     """Compile the filters of a Dashboard object into its Kibana view model representation.
 
     Args:
-        filters (list[FilterTypes]): The list of filter objects to compile.
+        filters (Sequence[FilterTypes]): The sequence of filter objects to compile.
 
     Returns:
         list[KbnFilter]: The compiled list of Kibana filter view models.

--- a/src/dashboard_compiler/panels/charts/esql/columns/compile.py
+++ b/src/dashboard_compiler/panels/charts/esql/columns/compile.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from dashboard_compiler.panels.charts.esql.columns.config import ESQLDimensionTypes, ESQLMetricTypes
 from dashboard_compiler.panels.charts.esql.columns.view import KbnESQLFieldDimensionColumn, KbnESQLFieldMetricColumn
 from dashboard_compiler.shared.config import random_id_generator, stable_id_generator
@@ -21,11 +23,11 @@ def compile_esql_metric(metric: ESQLMetricTypes) -> KbnESQLFieldMetricColumn:
     )
 
 
-def compile_esql_metrics(metrics: list[ESQLMetricTypes]) -> list[KbnESQLFieldMetricColumn]:
-    """Compile a list of ESQLMetricTypes into their Kibana view model representation.
+def compile_esql_metrics(metrics: Sequence[ESQLMetricTypes]) -> list[KbnESQLFieldMetricColumn]:
+    """Compile a sequence of ESQLMetricTypes into their Kibana view model representation.
 
     Args:
-        metrics (list[ESQLMetricTypes]): The list of ESQLMetricTypes objects to compile.
+        metrics (Sequence[ESQLMetricTypes]): The sequence of ESQLMetricTypes objects to compile.
 
     Returns:
         list[KbnESQLFieldMetricColumn]: A list of compiled KbnESQLFieldMetricColumn objects.
@@ -52,11 +54,11 @@ def compile_esql_dimension(dimension: ESQLDimensionTypes) -> KbnESQLFieldDimensi
     )
 
 
-def compile_esql_dimensions(dimensions: list[ESQLDimensionTypes]) -> list[KbnESQLFieldDimensionColumn]:
-    """Compile a list of ESQLDimensionTypes objects into their Kibana view model representation.
+def compile_esql_dimensions(dimensions: Sequence[ESQLDimensionTypes]) -> list[KbnESQLFieldDimensionColumn]:
+    """Compile a sequence of ESQLDimensionTypes objects into their Kibana view model representation.
 
     Args:
-        dimensions (list[ESQLDimensionTypes]): The list of ESQLDimensionTypes objects to compile.
+        dimensions (Sequence[ESQLDimensionTypes]): The sequence of ESQLDimensionTypes objects to compile.
 
     Returns:
         list[KbnESQLFieldDimensionColumn]: The compiled Kibana view model.

--- a/src/dashboard_compiler/panels/charts/lens/columns/compile.py
+++ b/src/dashboard_compiler/panels/charts/lens/columns/compile.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from dashboard_compiler.panels.charts.lens.columns.view import (
     KbnLensColumnTypes,
 )
@@ -7,12 +9,12 @@ from dashboard_compiler.panels.charts.lens.metrics.compile import compile_lens_m
 from dashboard_compiler.panels.charts.lens.metrics.config import LensMetricTypes
 
 
-def compile_lens_columns(dimensions: list[LensDimensionTypes], metrics: list[LensMetricTypes]) -> dict[str, KbnLensColumnTypes]:
-    """Compile a list of LensDimensionTypes and LensMetricTypes into their Kibana view model representation.
+def compile_lens_columns(dimensions: Sequence[LensDimensionTypes], metrics: Sequence[LensMetricTypes]) -> dict[str, KbnLensColumnTypes]:
+    """Compile sequences of LensDimensionTypes and LensMetricTypes into their Kibana view model representation.
 
     Args:
-        dimensions (list[LensDimensionTypes]): The list of LensDimensionTypes to compile.
-        metrics (list[LensMetricTypes]): The list of LensMetricTypes to compile.
+        dimensions (Sequence[LensDimensionTypes]): The sequence of LensDimensionTypes to compile.
+        metrics (Sequence[LensMetricTypes]): The sequence of LensMetricTypes to compile.
 
     Returns:
         dict[str, KbnLensColumnTypes]: A dictionary mapping column IDs to their compiled KbnLensColumnTypes.

--- a/src/dashboard_compiler/panels/charts/lens/dimensions/compile.py
+++ b/src/dashboard_compiler/panels/charts/lens/dimensions/compile.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping, Sequence
+
 from dashboard_compiler.panels.charts.lens.columns.view import (
     KbnLensCustomIntervalsDimensionColumnParentFormat,
     KbnLensCustomIntervalsDimensionColumnParentFormatParams,
@@ -41,13 +43,13 @@ GRANULARITY_TO_BARS = {
 
 def compile_lens_dimension(
     dimension: LensDimensionTypes,
-    kbn_metric_column_by_id: dict[str, KbnLensMetricColumnTypes],
+    kbn_metric_column_by_id: Mapping[str, KbnLensMetricColumnTypes],
 ) -> tuple[str, KbnLensDimensionColumnTypes]:
     """Compile a single LensDimensionTypes object into its Kibana view model.
 
     Args:
         dimension (LensDimensionTypes): The LensDimensionTypes object to compile.
-        kbn_metric_column_by_id (dict[str, KbnLensMetricColumnTypes]): A dictionary of compiled KbnLensFieldMetricColumn objects.
+        kbn_metric_column_by_id (Mapping[str, KbnLensMetricColumnTypes]): A mapping of compiled KbnLensFieldMetricColumn objects.
 
     Returns:
         tuple[str, KbnLensDimensionColumnTypes]: A tuple containing the dimension ID and the compiled Kibana view model.
@@ -174,14 +176,14 @@ def compile_lens_dimension(
 
 
 def compile_lens_dimensions(
-    dimensions: list[LensDimensionTypes],
-    kbn_metric_column_by_id: dict[str, KbnLensMetricColumnTypes],
+    dimensions: Sequence[LensDimensionTypes],
+    kbn_metric_column_by_id: Mapping[str, KbnLensMetricColumnTypes],
 ) -> dict[str, KbnLensDimensionColumnTypes]:
-    """Compile a list of LensDimensionTypes objects into their Kibana view model representation.
+    """Compile a sequence of LensDimensionTypes objects into their Kibana view model representation.
 
     Args:
-        dimensions (list[LensDimensionTypes]): The list of LensDimensionTypes objects to compile.
-        kbn_metric_column_by_id (dict[str, KbnLensMetricColumnTypes]): A dictionary of compiled KbnLensFieldMetricColumn objects.
+        dimensions (Sequence[LensDimensionTypes]): The sequence of LensDimensionTypes objects to compile.
+        kbn_metric_column_by_id (Mapping[str, KbnLensMetricColumnTypes]): A mapping of compiled KbnLensFieldMetricColumn objects.
 
     Returns:
         dict[str, KbnLensDimensionColumnTypes]: A dictionary of compiled KbnLensDimensionColumnTypes objects.

--- a/src/dashboard_compiler/panels/charts/lens/metrics/compile.py
+++ b/src/dashboard_compiler/panels/charts/lens/metrics/compile.py
@@ -1,5 +1,7 @@
 """Compile Lens metrics into their Kibana view models."""
 
+from collections.abc import Sequence
+
 from humanize import ordinal
 
 from dashboard_compiler.panels.charts.lens.columns.view import (
@@ -210,14 +212,14 @@ def compile_lens_metric(metric: LensMetricTypes) -> tuple[str, KbnLensMetricColu
     )
 
 
-def compile_lens_metrics(metrics: list[LensMetricTypes]) -> dict[str, KbnLensMetricColumnTypes]:
-    """Compile a list of LensMetricTypes into their Kibana view model representation.
+def compile_lens_metrics(metrics: Sequence[LensMetricTypes]) -> dict[str, KbnLensMetricColumnTypes]:
+    """Compile a sequence of LensMetricTypes into their Kibana view model representation.
 
     Args:
-        metrics (list[LensMetricTypes]): The list of LensMetricTypes objects to compile.
+        metrics (Sequence[LensMetricTypes]): The sequence of LensMetricTypes objects to compile.
 
     Returns:
-        tuple[dict[str, KbnLensColumnTypes]] A dictionary of metric IDs to their compiled KbnLensColumnTypes.
+        dict[str, KbnLensMetricColumnTypes]: A dictionary of metric IDs to their compiled KbnLensColumnTypes.
 
     """
     compiled_metrics = [compile_lens_metric(metric) for metric in metrics]

--- a/src/dashboard_compiler/panels/compile.py
+++ b/src/dashboard_compiler/panels/compile.py
@@ -1,5 +1,7 @@
 """Compile Dashboard Panels to Kibana View Models."""
 
+from collections.abc import Sequence
+
 from dashboard_compiler.panels import LinksPanel, MarkdownPanel
 from dashboard_compiler.panels.charts.compile import compile_charts_panel_config
 from dashboard_compiler.panels.charts.config import ESQLPanel, LensPanel
@@ -80,14 +82,14 @@ def compile_dashboard_panel(panel: PanelTypes) -> tuple[list[KbnReference], KbnP
     raise NotImplementedError(msg)
 
 
-def compile_dashboard_panels(panels: list[PanelTypes]) -> tuple[list[KbnReference], list[KbnBasePanel]]:
+def compile_dashboard_panels(panels: Sequence[PanelTypes]) -> tuple[list[KbnReference], list[KbnBasePanel]]:
     """Compile the panels of a Dashboard object into their Kibana view model representation.
 
     Args:
-        panels (list): The list of panel objects to compile.
+        panels (Sequence[PanelTypes]): The sequence of panel objects to compile.
 
     Returns:
-        list: The compiled list of Kibana panel view models.
+        tuple[list[KbnReference], list[KbnBasePanel]]: The compiled references and panel view models.
 
     """
     kbn_panels: list[KbnBasePanel] = []

--- a/src/dashboard_compiler/panels/links/compile.py
+++ b/src/dashboard_compiler/panels/links/compile.py
@@ -1,5 +1,7 @@
 """Compile links for a dashboard into their Kibana view models."""
 
+from collections.abc import Sequence
+
 from dashboard_compiler.panels.links.config import BaseLink, DashboardLink, LinksPanel, LinkTypes, UrlLink
 from dashboard_compiler.panels.links.view import (
     KbnDashboardLink,
@@ -115,15 +117,14 @@ def compile_link(link: BaseLink, order: int) -> tuple[KbnReference | None, KbnLi
     raise NotImplementedError(msg)
 
 
-def compile_links(links: list[LinkTypes]) -> tuple[list[KbnReference], list[KbnLinkTypes]]:
-    """Convert a list of KbnLink objects to a list of KbnReference objects.
+def compile_links(links: Sequence[LinkTypes]) -> tuple[list[KbnReference], list[KbnLinkTypes]]:
+    """Convert a sequence of KbnLink objects to lists of KbnReference and KbnLink objects.
 
     Args:
-        links (list[KbnLink]): The list of KbnLink objects to convert.
-        panel_index (str): The index of the panel to which these links belong.
+        links (Sequence[LinkTypes]): The sequence of link objects to convert.
 
     Returns:
-        list[KbnReference]: The converted list of KbnReference objects.
+        tuple[list[KbnReference], list[KbnLinkTypes]]: The converted references and link objects.
 
     """
     kbn_references: list[KbnReference] = []

--- a/src/dashboard_compiler/shared/config.py
+++ b/src/dashboard_compiler/shared/config.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import uuid
+from collections.abc import Sequence
 from typing import Literal
 
 from pydantic import Field
@@ -20,7 +21,7 @@ def random_id_generator() -> str:
     return str(uuid.uuid4())
 
 
-def stable_id_generator(values: list[str | int | float | None]) -> str:
+def stable_id_generator(values: Sequence[str | int | float | None]) -> str:
     """Generate a GUID looking string from a hash of values.
 
     This produces a stable ID as long as the input values are stable.


### PR DESCRIPTION
## Summary

Implements #58 by using abstract types (`Sequence`, `Mapping`) instead of concrete types (`list`, `dict`) for function parameters that only read from collections. This provides more flexibility for API consumers while maintaining strict validation in Pydantic models.

## Changes

- Use `Sequence[T]` instead of `list[T]` for function parameters that iterate
- Use `Mapping[K, V]` instead of `dict[K, V]` for read-only dictionary parameters
- Add imports from `collections.abc`

## Testing

- ✅ Type checker: Fixed 2 pre-existing type errors
- ✅ Tests: 76 passed, 13 failed (pre-existing failures)
- ✅ No regressions introduced

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)