### PR TITLE
Align pyproject.toml with py-key-value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 
 install:
 	@echo "Running uv sync..."
-	uv sync --all-extras
+	uv sync --group dev
 	@echo "Installing markdownlint-cli..."
 	npm install -g markdownlint-cli
 
@@ -103,7 +103,7 @@ clean-full: clean
 setup:
 	@echo "Setting up environment..."
 	curl -LsSf https://astral.sh/uv/install.sh | sh
-	uv sync --all-extras
+	uv sync --group dev
 	echo "Environment set up successfully!"
 
 update-deps:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This tool simplifies the process of creating and managing Kibana dashboards by a
 This project uses [uv](https://github.com/astral-sh/uv) for fast, reliable Python package management:
 
 ```bash
-uv sync --all-extras
+uv sync --group dev
 ```
 
 For more information, see the [uv documentation](https://docs.astral.sh/uv/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ description = "Compiles dashboard definitions from YAML to Kibana format"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Code Generators",
+]
 dependencies = [
     "pyyaml>=6.0",
     "pydantic>=2.11.3",
@@ -15,7 +23,15 @@ dependencies = [
     "aiohttp>=3.9.0",
 ]
 
-[project.optional-dependencies]
+[project.scripts]
+kb-dashboard = "dashboard_compiler.cli:cli"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "auto"
+addopts = "-vv"
+
+[dependency-groups]
 dev = [
     "pytest>=7.0",
     "syrupy>=4.9.1",
@@ -33,27 +49,17 @@ docs = [
     "mkdocstrings-python>=1.10.0",
 ]
 
-[project.scripts]
-kb-dashboard = "dashboard_compiler.cli:cli"
-
-[tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"
-asyncio_mode = "auto" 
-addopts = "-vv"
-
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.8.2,<0.9.0"]
+build-backend = "uv_build"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/dashboard_compiler"]
+[tool.uv.build-backend]
+module-name = "dashboard_compiler"
 
 [tool.ruff]
 line-length = 140
 # Assume Python 3.12
 target-version = "py312"
-# Exclude files/directories listed in .gitignore
-respect-gitignore = true
 # Add commonly ignored directories
 extend-exclude = [
     ".git",
@@ -83,10 +89,6 @@ ignore = [
     "D413",    # multi-line-summary-second-line
     "D100",    # Ignore missing docstrings for modules
 ]
-
-# Allow fix for all enabled rules (when `--fix`) is provided.
-fixable = ["ALL"]
-unfixable = []
 
 # Per-file rule ignores
 [tool.ruff.lint.per-file-ignores]

--- a/uv.lock
+++ b/uv.lock
@@ -119,6 +119,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -272,10 +281,11 @@ dependencies = [
     { name = "rich-click" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
     { name = "deepdiff" },
+    { name = "inline-snapshot" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-freezer" },
@@ -292,25 +302,31 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.21.0" },
     { name = "beartype", specifier = ">=0.20.2" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "deepdiff", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "humanize", specifier = ">=4.12.3" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.30.0" },
-    { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.10.0" },
     { name = "pydantic", specifier = ">=2.11.3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
-    { name = "pytest-freezer", marker = "extra == 'dev'", specifier = ">=0.4.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich-click", specifier = ">=1.9.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.6" },
-    { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.9.1" },
 ]
-provides-extras = ["dev", "docs"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "basedpyright", specifier = ">=1.21.0" },
+    { name = "deepdiff", specifier = ">=8.4.2" },
+    { name = "inline-snapshot", specifier = ">=0.31.1" },
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-freezer", specifier = ">=0.4.9" },
+    { name = "ruff", specifier = ">=0.11.6" },
+    { name = "syrupy", specifier = ">=4.9.1" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.0" },
+    { name = "mkdocstrings-python", specifier = ">=1.10.0" },
+]
 
 [[package]]
 name = "deepdiff"
@@ -322,6 +338,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/76/36c9aab3d5c19a94091f7c6c6e784efca50d87b124bf026c36e94719f33c/deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a", size = 634054, upload-time = "2025-09-03T19:40:41.461Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b", size = 91378, upload-time = "2025-09-03T19:40:39.679Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -451,11 +476,11 @@ wheels = [
 
 [[package]]
 name = "humanize"
-version = "4.15.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/43/50033d25ad96a7f3845f40999b4778f753c3901a11808a584fed7c00d9f5/humanize-4.14.0.tar.gz", hash = "sha256:2fa092705ea640d605c435b1ca82b2866a1b601cdf96f076d70b79a855eba90d", size = 82939, upload-time = "2025-10-15T13:04:51.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/9512c5fb6c8218332b530f13500c6ff5f3ce3342f35e0dd7be9ac3856fd3/humanize-4.14.0-py3-none-any.whl", hash = "sha256:d57701248d040ad456092820e6fde56c930f17749956ac47f4f655c0c547bfff", size = 132092, upload-time = "2025-10-15T13:04:49.404Z" },
 ]
 
 [[package]]
@@ -474,6 +499,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b1/52b5ee59f73ed31d5fe21b10881bf2d121d07d54b23c0b6b74186792e620/inline_snapshot-0.31.1.tar.gz", hash = "sha256:4ea5ed70aa1d652713bbfd750606b94bd8a42483f7d3680433b3e92994495f64", size = 2606338, upload-time = "2025-11-07T07:36:18.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/52/945db420380efbda8c69a7a4a16c53df9d7ac50d8217286b9d41e5d825ff/inline_snapshot-0.31.1-py3-none-any.whl", hash = "sha256:7875a73c986a03388c7e758fb5cb8a43d2c3a20328aa1d851bfb4ed536c4496f", size = 71965, upload-time = "2025-11-07T07:36:16.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Modernizes pyproject.toml to match py-key-value's cleaner, more minimal configuration approach.

## Changes

- Switch from hatchling to uv_build backend
- Add PyPI classifiers for better package metadata
- Migrate from [project.optional-dependencies] to [dependency-groups]
- Remove redundant Ruff settings (respect-gitignore, fixable, unfixable)
- Update Makefile and README to use --group dev instead of --all-extras

## Validation

- ✅ Build tested successfully with `uv build`
- ✅ Dependencies sync correctly with `uv sync --group dev`

Closes #49

---
Generated with [Claude Code](https://claude.ai/code)