### PR TITLE
feat: Support collapse Functions on Dimensions and multi-metric/dimension pie charts

### DIFF
--- a/src/dashboard_compiler/panels/charts/esql/columns/config.py
+++ b/src/dashboard_compiler/panels/charts/esql/columns/config.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from dashboard_compiler.panels.charts.lens.dimensions.config import CollapseAggregationEnum
 from dashboard_compiler.shared.config import BaseCfgModel
 
 type ESQLColumnTypes = ESQLDimension | ESQLMetric
@@ -24,6 +25,9 @@ class ESQLDimension(BaseESQLColumn):
 
     field: str = Field(default=...)
     """The field to use for the dimension."""
+
+    collapse: CollapseAggregationEnum | None = Field(default=None, strict=False)
+    """The collapse function to apply to this dimension (sum, avg, min, max)."""
 
 
 class ESQLMetric(BaseESQLColumn):

--- a/src/dashboard_compiler/panels/charts/lens/dimensions/config.py
+++ b/src/dashboard_compiler/panels/charts/lens/dimensions/config.py
@@ -66,6 +66,9 @@ class LensFiltersDimension(BaseLensDimension):
     filters: list[LensFiltersDimensionFilter] = Field(default=...)
     """The filters to use for the dimension."""
 
+    collapse: CollapseAggregationEnum | None = Field(default=None, strict=False)
+    """The collapse function to apply to this dimension (sum, avg, min, max)."""
+
 
 class LensIntervalsDimensionInterval(BaseCfgModel):
     """A single interval for an intervals dimension."""
@@ -98,8 +101,8 @@ class LensIntervalsDimension(BaseLensDimension):
     """Interval granularity divides the field into evenly spaced intervals based on the minimum and maximum values for the field.
     Kibana defaults to 4 if not specified."""
 
-    collapse: CollapseAggregationEnum | None = Field(default=None)
-    """The aggregation to use for the dimension."""
+    collapse: CollapseAggregationEnum | None = Field(default=None, strict=False)
+    """The collapse function to apply to this dimension (sum, avg, min, max)."""
 
     empty_bucket: bool | None = Field(default=None)
     """If `true`, show a bucket for documents with a missing value for the field. Defaults to `false`."""
@@ -140,6 +143,9 @@ class LensTopValuesDimension(BaseLensDimension):
     exclude_is_regex: bool | None = Field(default=None)
     """If `true`, treat the values in the `exclude` list as regular expressions. Defaults to `false`."""
 
+    collapse: CollapseAggregationEnum | None = Field(default=None, strict=False)
+    """The collapse function to apply to this dimension (sum, avg, min, max)."""
+
 
 class LensDateHistogramDimension(BaseLensDimension):
     """Represents a histogram dimension configuration within a Lens chart.
@@ -158,5 +164,5 @@ class LensDateHistogramDimension(BaseLensDimension):
     partial_intervals: bool | None = Field(default=None)
     """If `true`, show partial intervals. Kibana defaults to `true` if not specified."""
 
-    collapse: CollapseAggregationEnum | None = Field(default=None)
-    """The aggregation to use for the dimension."""
+    collapse: CollapseAggregationEnum | None = Field(default=None, strict=False)
+    """The collapse function to apply to this dimension (sum, avg, min, max)."""

--- a/src/dashboard_compiler/panels/charts/pie/compile.py
+++ b/src/dashboard_compiler/panels/charts/pie/compile.py
@@ -25,7 +25,9 @@ def compile_pie_chart_visualization_state(
     layer_id: str,
     chart: LensPieChart | ESQLPieChart,
     slice_by_ids: list[str],
+    secondary_slice_by_ids: list[str] | None,
     metric_ids: list[str],
+    collapse_fns: dict[str, str] | None,
 ) -> KbnPieVisualizationState:
     """Compile a PieChart config object into a Kibana Pie visualization state.
 
@@ -33,7 +35,9 @@ def compile_pie_chart_visualization_state(
         layer_id (str): The ID of the layer.
         chart (LensPieChart | ESQLPieChart): The PieChart config object.
         slice_by_ids (list[str]): The IDs of the slice by dimensions.
-        metric_ids (list[str]): The IDs of the metric.
+        secondary_slice_by_ids (list[str] | None): The IDs of the secondary slice by dimensions.
+        metric_ids (list[str]): The IDs of the metrics.
+        collapse_fns (dict[str, str] | None): Mapping of dimension ID to collapse function.
 
     Returns:
         tuple[str, KbnPieVisualizationState]: The layer ID and the compiled visualization state.
@@ -74,17 +78,24 @@ def compile_pie_chart_visualization_state(
     if chart.color and chart.color.palette:
         kbn_color_mapping = KbnLayerColorMapping(paletteId=chart.color.palette)
 
+    # Determine if multiple metrics are allowed
+    allow_multiple_metrics = True if len(metric_ids) > 1 else None
+    empty_size_ratio = 0.0 if len(metric_ids) > 1 else None
+
     kbn_layer_visualization = KbnPieStateVisualizationLayer(
         layerId=layer_id,
         primaryGroups=slice_by_ids,
+        secondaryGroups=secondary_slice_by_ids if secondary_slice_by_ids else None,
         metrics=metric_ids,
+        allowMultipleMetrics=allow_multiple_metrics,
+        collapseFns=collapse_fns if collapse_fns else None,
         numberDisplay=number_display,
         categoryDisplay=category_display,
         legendDisplay=legend_display,
         nestedLegend=False,
         layerType='data',
         colorMapping=kbn_color_mapping,
-        emptySizeRatio=0 if len(metric_ids) > 1 else None,
+        emptySizeRatio=empty_size_ratio,
         legendSize=legend_size,
         truncateLegend=False if truncate_legend == 0 else None,
         legendMaxLines=legend_max_lines,
@@ -104,18 +115,50 @@ def compile_lens_pie_chart(lens_pie_chart: LensPieChart) -> tuple[str, dict[str,
 
     """
     layer_id = lens_pie_chart.id or random_id_generator()
-    metric_id: str
-    metric: KbnLensMetricColumnTypes
-    metric_id, metric = compile_lens_metric(metric=lens_pie_chart.metric)
 
-    kbn_metric_column_by_id: dict[str, KbnLensMetricColumnTypes] = {metric_id: metric}
+    # Handle single metric or multiple metrics
+    metric_configs = []
+    if lens_pie_chart.metric:
+        metric_configs = [lens_pie_chart.metric]
+    elif lens_pie_chart.metrics:
+        metric_configs = lens_pie_chart.metrics
+    else:
+        msg = "Either 'metric' or 'metrics' must be provided"
+        raise ValueError(msg)
 
+    # Compile metrics
+    kbn_metric_column_by_id: dict[str, KbnLensMetricColumnTypes] = {}
+    metric_ids: list[str] = []
+    for metric_config in metric_configs:
+        metric_id, metric = compile_lens_metric(metric=metric_config)
+        kbn_metric_column_by_id[metric_id] = metric
+        metric_ids.append(metric_id)
+
+    # Compile dimensions (first is primary, rest are secondary)
     slices_by_ids = compile_lens_dimensions(dimensions=lens_pie_chart.slice_by, kbn_metric_column_by_id=kbn_metric_column_by_id)
-    slice_by_ids = list(slices_by_ids.keys())
+    all_dimension_ids = list(slices_by_ids.keys())
 
-    kbn_columns: dict[str, KbnLensColumnTypes] = {**slices_by_ids, metric_id: metric}
+    # First dimension is primary, rest are secondary
+    primary_dimension_ids = [all_dimension_ids[0]] if all_dimension_ids else []
+    secondary_dimension_ids = all_dimension_ids[1:] if len(all_dimension_ids) > 1 else None
 
-    return layer_id, kbn_columns, compile_pie_chart_visualization_state(layer_id, lens_pie_chart, slice_by_ids, [metric_id])
+    # Build collapse functions mapping from dimension.collapse properties
+    collapse_fns: dict[str, str] | None = None
+    for dim_config, compiled_dim_id in zip(lens_pie_chart.slice_by, all_dimension_ids, strict=True):
+        if dim_config.collapse:
+            if collapse_fns is None:
+                collapse_fns = {}
+            collapse_fns[compiled_dim_id] = str(dim_config.collapse)
+
+    kbn_columns: dict[str, KbnLensColumnTypes] = {**slices_by_ids, **kbn_metric_column_by_id}
+
+    return (
+        layer_id,
+        kbn_columns,
+        compile_pie_chart_visualization_state(
+            layer_id, lens_pie_chart, primary_dimension_ids, secondary_dimension_ids, metric_ids, collapse_fns
+        ),
+    )
 
 
 def compile_esql_pie_chart(
@@ -132,11 +175,37 @@ def compile_esql_pie_chart(
     """
     layer_id = esql_pie_chart.id or random_id_generator()
 
-    metric = compile_esql_metric(esql_pie_chart.metric)
+    # Handle single metric or multiple metrics
+    metric_configs = []
+    if esql_pie_chart.metric:
+        metric_configs = [esql_pie_chart.metric]
+    elif esql_pie_chart.metrics:
+        metric_configs = esql_pie_chart.metrics
+    else:
+        msg = "Either 'metric' or 'metrics' must be provided"
+        raise ValueError(msg)
 
+    # Compile metrics
+    metrics = [compile_esql_metric(m) for m in metric_configs]
+    metric_ids = [m.columnId for m in metrics]
+
+    # Compile dimensions (first is primary, rest are secondary)
     dimensions = compile_esql_dimensions(dimensions=esql_pie_chart.slice_by)
+    all_dimension_ids = [d.columnId for d in dimensions]
 
-    kbn_columns: list[KbnESQLColumnTypes] = [metric, *dimensions]
+    # First dimension is primary, rest are secondary
+    primary_dimension_ids = [all_dimension_ids[0]] if all_dimension_ids else []
+    secondary_dimension_ids = all_dimension_ids[1:] if len(all_dimension_ids) > 1 else None
+
+    # Build collapse functions mapping from dimension.collapse properties
+    collapse_fns: dict[str, str] | None = None
+    for dim_config, compiled_dim in zip(esql_pie_chart.slice_by, dimensions, strict=True):
+        if dim_config.collapse:
+            if collapse_fns is None:
+                collapse_fns = {}
+            collapse_fns[compiled_dim.columnId] = str(dim_config.collapse)
+
+    kbn_columns: list[KbnESQLColumnTypes] = [*metrics, *dimensions]
 
     return (
         layer_id,
@@ -144,7 +213,9 @@ def compile_esql_pie_chart(
         compile_pie_chart_visualization_state(
             layer_id=layer_id,
             chart=esql_pie_chart,
-            slice_by_ids=[column.columnId for column in dimensions],
-            metric_ids=[metric.columnId],
+            slice_by_ids=primary_dimension_ids,
+            secondary_slice_by_ids=secondary_dimension_ids,
+            metric_ids=metric_ids,
+            collapse_fns=collapse_fns,
         ),
     )

--- a/src/dashboard_compiler/panels/charts/pie/config.py
+++ b/src/dashboard_compiler/panels/charts/pie/config.py
@@ -132,22 +132,27 @@ class LensPieChart(BasePieChart):
     data_view: str = Field(default=...)
     """The data view that determines the data for the pie chart."""
 
-    metric: LensMetricTypes = Field(default=...)
-    """A metric that determines the size of the slice of the pie chart."""
+    metric: LensMetricTypes | None = Field(default=None)
+    """A metric that determines the size of the slice of the pie chart. Use this for single metric charts."""
+
+    metrics: list[LensMetricTypes] | None = Field(default=None)
+    """Multiple metrics for the pie chart. Use this for multi-metric charts."""
 
     slice_by: list[LensDimensionTypes] = Field(default=...)
-    """The dimensions that determine the slices of the pie chart."""
+    """The dimensions that determine the slices of the pie chart. First dimension is primary, additional dimensions are secondary."""
 
 
 class ESQLPieChart(BasePieChart):
-    """Represents a Pie chart configuration within an ES|QL panel.
+    """Represents a Pie chart configuration within an ES|QL panel."""
 
-    Note: The ES|QL query is defined at the panel level (ESQLPanel.esql),
-    not at the chart level.
-    """
+    metric: ESQLMetricTypes | None = Field(default=None)
+    """A metric that determines the size of the slice of the pie chart. Use this for single metric charts."""
 
-    metric: ESQLMetricTypes = Field(default=...)
-    """A metric that determines the size of the slice of the pie chart."""
+    metrics: list[ESQLMetricTypes] | None = Field(default=None)
+    """Multiple metrics for the pie chart. Use this for multi-metric charts."""
 
     slice_by: list[ESQLDimensionTypes] = Field(default=...)
-    """The dimensions that determine the slices of the pie chart."""
+    """The dimensions that determine the slices of the pie chart. First dimension is primary, additional dimensions are secondary."""
+
+    esql: str = Field(default=...)
+    """The ES|QL query that determines the data for the pie chart."""

--- a/src/dashboard_compiler/panels/charts/pie/view.py
+++ b/src/dashboard_compiler/panels/charts/pie/view.py
@@ -9,7 +9,10 @@ from dashboard_compiler.shared.view import OmitIfNone
 class KbnPieStateVisualizationLayer(KbnBaseStateVisualizationLayer):
     layerType: Literal['data'] = 'data'
     primaryGroups: list[str]
+    secondaryGroups: Annotated[list[str] | None, OmitIfNone()] = Field(None)
     metrics: list[str]
+    allowMultipleMetrics: Annotated[bool | None, OmitIfNone()] = Field(None)
+    collapseFns: Annotated[dict[str, str] | None, OmitIfNone()] = Field(None)
     numberDisplay: str
     categoryDisplay: str
     legendDisplay: str

--- a/tests/panels/charts/pie/test_pie_data.py
+++ b/tests/panels/charts/pie/test_pie_data.py
@@ -30,6 +30,35 @@ ESQL_PIE_DIMENSION = {
     'id': '6e73286b-85cf-4343-9676-b7ee2ed0a3df',
 }
 
+LENS_PIE_DIMENSION_2 = {
+    'field': 'region',
+    'id': '7f84397c-95f0-5454-bd88-c8ff3fe1b4eg',
+}
+
+LENS_PIE_METRIC_2 = {'aggregation': 'sum', 'field': 'bytes', 'id': '9g131718-490f-5c65-cd0f-f6661g95g6f7'}
+
+ESQL_PIE_DIMENSION_2 = {
+    'field': 'region',
+    'id': '7f84397c-95f0-5454-bd88-c8ff3fe1b4eg',
+}
+
+ESQL_PIE_METRIC_2 = {
+    'field': 'sum(bytes)',
+    'id': '9g131718-490f-5c65-cd0f-f6661g95g6f7',
+}
+
+LENS_PIE_DIMENSION_WITH_COLLAPSE = {
+    'field': 'aerospike.namespace.name',
+    'id': '6e73286b-85cf-4343-9676-b7ee2ed0a3df',
+    'collapse': 'sum',
+}
+
+ESQL_PIE_DIMENSION_WITH_COLLAPSE = {
+    'field': 'aerospike.namespace.name',
+    'id': '6e73286b-85cf-4343-9676-b7ee2ed0a3df',
+    'collapse': 'sum',
+}
+
 
 CASE_PIE_CHART: TestCaseType = (
     {
@@ -43,6 +72,7 @@ CASE_PIE_CHART: TestCaseType = (
     },
     {
         'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*) by aerospike.namespace',
         'metric': ESQL_PIE_METRIC,
         'slice_by': [ESQL_PIE_DIMENSION],
         'color': {
@@ -86,6 +116,7 @@ CASE_DONUT_CHART: TestCaseType = (
     },
     {
         'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*) by aerospike.namespace',
         'metric': ESQL_PIE_METRIC,
         'slice_by': [ESQL_PIE_DIMENSION],
         'appearance': {
@@ -133,6 +164,7 @@ CASE_PIE_CHART_INSIDE_LABELS_INTEGER_VALUES: TestCaseType = (
     },
     {
         'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*) by aerospike.namespace',
         'metric': ESQL_PIE_METRIC,
         'slice_by': [ESQL_PIE_DIMENSION],
         'titles_and_text': {
@@ -182,6 +214,7 @@ CASE_PIE_CHART_SHOW_LARGE_LEGEND_NO_TRUNCATE: TestCaseType = (
     },
     {
         'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*) by aerospike.namespace',
         'metric': ESQL_PIE_METRIC,
         'slice_by': [ESQL_PIE_DIMENSION],
         'legend': {
@@ -217,11 +250,141 @@ CASE_PIE_CHART_SHOW_LARGE_LEGEND_NO_TRUNCATE: TestCaseType = (
 )
 """Tuple[Config as Dict, View as Dict, References as List] for a pie chart with a large legend and no label truncation."""
 
+CASE_PIE_CHART_WITH_SECONDARY_GROUPS: TestCaseType = (
+    {
+        'type': 'pie',
+        'data_view': 'metrics-*',
+        'metric': LENS_PIE_METRIC,
+        'slice_by': [LENS_PIE_DIMENSION, LENS_PIE_DIMENSION_2],
+        'color': {
+            'palette': 'eui_amsterdam_color_blind',
+        },
+    },
+    {
+        'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*) by aerospike.namespace, region',
+        'metric': ESQL_PIE_METRIC,
+        'slice_by': [ESQL_PIE_DIMENSION, ESQL_PIE_DIMENSION_2],
+        'color': {
+            'palette': 'eui_amsterdam_color_blind',
+        },
+    },
+    {
+        'shape': 'pie',
+    },
+    {
+        'layerId': 'a72f6386-04e9-4228-ab7a-6e5edb63ca4a',
+        'primaryGroups': ['6e73286b-85cf-4343-9676-b7ee2ed0a3df'],
+        'secondaryGroups': ['7f84397c-95f0-5454-bd88-c8ff3fe1b4eg'],
+        'metrics': ['8f020607-379e-4b54-bc9e-e5550e84f5d5'],
+        'numberDisplay': 'percent',
+        'categoryDisplay': 'default',
+        'legendDisplay': 'default',
+        'nestedLegend': False,
+        'layerType': 'data',
+        'colorMapping': {
+            'assignments': [],
+            'specialAssignments': [{'rule': {'type': 'other'}, 'color': {'type': 'loop'}, 'touched': False}],
+            'paletteId': 'eui_amsterdam_color_blind',
+            'colorMode': {'type': 'categorical'},
+        },
+    },
+)
+"""Tuple[Config as Dict, View as Dict, References as List] for a pie chart with secondary groups."""
+
+CASE_PIE_CHART_WITH_MULTIPLE_METRICS: TestCaseType = (
+    {
+        'type': 'pie',
+        'data_view': 'metrics-*',
+        'metrics': [LENS_PIE_METRIC, LENS_PIE_METRIC_2],
+        'slice_by': [LENS_PIE_DIMENSION],
+        'color': {
+            'palette': 'eui_amsterdam_color_blind',
+        },
+    },
+    {
+        'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*), sum(bytes) by aerospike.namespace',
+        'metrics': [ESQL_PIE_METRIC, ESQL_PIE_METRIC_2],
+        'slice_by': [ESQL_PIE_DIMENSION],
+        'color': {
+            'palette': 'eui_amsterdam_color_blind',
+        },
+    },
+    {
+        'shape': 'pie',
+    },
+    {
+        'layerId': 'a72f6386-04e9-4228-ab7a-6e5edb63ca4a',
+        'primaryGroups': ['6e73286b-85cf-4343-9676-b7ee2ed0a3df'],
+        'metrics': ['8f020607-379e-4b54-bc9e-e5550e84f5d5', '9g131718-490f-5c65-cd0f-f6661g95g6f7'],
+        'allowMultipleMetrics': True,
+        'numberDisplay': 'percent',
+        'categoryDisplay': 'default',
+        'legendDisplay': 'default',
+        'nestedLegend': False,
+        'layerType': 'data',
+        'colorMapping': {
+            'assignments': [],
+            'specialAssignments': [{'rule': {'type': 'other'}, 'color': {'type': 'loop'}, 'touched': False}],
+            'paletteId': 'eui_amsterdam_color_blind',
+            'colorMode': {'type': 'categorical'},
+        },
+        'emptySizeRatio': 0.0,
+    },
+)
+"""Tuple[Config as Dict, View as Dict, References as List] for a pie chart with multiple metrics."""
+
+CASE_PIE_CHART_WITH_COLLAPSE_FUNCTIONS: TestCaseType = (
+    {
+        'type': 'pie',
+        'data_view': 'metrics-*',
+        'metric': LENS_PIE_METRIC,
+        'slice_by': [LENS_PIE_DIMENSION_WITH_COLLAPSE],
+        'color': {
+            'palette': 'eui_amsterdam_color_blind',
+        },
+    },
+    {
+        'type': 'pie',
+        'esql': 'FROM metrics-* | STATS count(*) by aerospike.namespace',
+        'metric': ESQL_PIE_METRIC,
+        'slice_by': [ESQL_PIE_DIMENSION_WITH_COLLAPSE],
+        'color': {
+            'palette': 'eui_amsterdam_color_blind',
+        },
+    },
+    {
+        'shape': 'pie',
+    },
+    {
+        'layerId': 'a72f6386-04e9-4228-ab7a-6e5edb63ca4a',
+        'primaryGroups': ['6e73286b-85cf-4343-9676-b7ee2ed0a3df'],
+        'metrics': ['8f020607-379e-4b54-bc9e-e5550e84f5d5'],
+        'collapseFns': {'6e73286b-85cf-4343-9676-b7ee2ed0a3df': 'sum'},
+        'numberDisplay': 'percent',
+        'categoryDisplay': 'default',
+        'legendDisplay': 'default',
+        'nestedLegend': False,
+        'layerType': 'data',
+        'colorMapping': {
+            'assignments': [],
+            'specialAssignments': [{'rule': {'type': 'other'}, 'color': {'type': 'loop'}, 'touched': False}],
+            'paletteId': 'eui_amsterdam_color_blind',
+            'colorMode': {'type': 'categorical'},
+        },
+    },
+)
+"""Tuple[Config as Dict, View as Dict, References as List] for a pie chart with collapse functions."""
+
 TEST_CASES = [
     CASE_PIE_CHART,
     CASE_DONUT_CHART,
     CASE_PIE_CHART_INSIDE_LABELS_INTEGER_VALUES,
     CASE_PIE_CHART_SHOW_LARGE_LEGEND_NO_TRUNCATE,
+    CASE_PIE_CHART_WITH_SECONDARY_GROUPS,
+    CASE_PIE_CHART_WITH_MULTIPLE_METRICS,
+    CASE_PIE_CHART_WITH_COLLAPSE_FUNCTIONS,
 ]
 
 TEST_CASE_IDS = [
@@ -229,4 +392,7 @@ TEST_CASE_IDS = [
     'Basic Donut Chart',
     'Pie Chart with Inside Labels and Integer Values',
     'Pie Chart with Large Legend and No Label Truncation',
+    'Pie Chart with Secondary Groups',
+    'Pie Chart with Multiple Metrics',
+    'Pie Chart with Collapse Functions',
 ]


### PR DESCRIPTION
## Summary

Refactors collapse functions from a chart-level mapping to a dimension-level property for more intuitive YAML syntax. Also adds support for multiple metrics and secondary groups in pie charts.

## Changes

- Add `collapse` field to all Lens and ES|QL dimension types
- Update pie chart config to support `metrics` (list) and `secondary_slice_by`
- Remove chart-level `collapse_fns` mapping
- Build collapseFns mapping from dimension.collapse during compilation
- Add comprehensive test coverage for all new features

## Breaking Change

`collapse_fns` chart-level field removed. Use `collapse` property on individual dimensions instead.

## Testing

✅ All 104 tests passing
✅ Backward compatibility maintained for single metric
✅ Works for both Lens and ES|QL pie charts

Fixes #109

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pie charts: support for multiple metrics, primary+secondary slice breakdowns, and per-dimension aggregation (collapse) functions.
  * VS Code extension: compiler moved to an LSP-backed implementation for the extension lifecycle and requests.

* **Tests**
  * Added test cases covering secondary groups, multiple metrics, and collapse-function scenarios for pie charts.

* **Documentation**
  * Dashboard config docs updated to use dashboards[] / per-dashboard controls; several planning/hand-off documents removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->