### PR TITLE
docs: fix dashboard field name and other documentation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more information, see the [uv documentation](https://docs.astral.sh/uv/).
 
 ```yaml
 dashboard:
-  title: My First Dashboard
+  name: My First Dashboard
   description: A simple dashboard with markdown
   panels:
     - panel:

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ For more information, see the [uv documentation](https://docs.astral.sh/uv/).
 
 ```yaml
 dashboard:
-  title: My First Dashboard
+  name: My First Dashboard
   description: A simple dashboard with markdown
   panels:
     - panel:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ A basic dashboard YAML file has the following structure:
 
 ```yaml
 dashboard:
-  title: Your Dashboard Title
+  name: Your Dashboard Title
   description: An optional description
   panels:
     - # Your panel definitions go here
@@ -30,7 +30,7 @@ Here's an example of a dashboard with a single markdown panel:
 
 ```yaml
 dashboard:
-  title: My First Dashboard
+  name: My First Dashboard
   description: A simple dashboard with a markdown panel
   panels:
     - panel:
@@ -48,7 +48,7 @@ Here's an example of a dashboard with a single Lens metric panel displaying a co
 
 ```yaml
 dashboard:
-  title: Metric Dashboard
+  name: Metric Dashboard
   description: A dashboard with a single metric panel
   panels:
     - panel:

--- a/docs/yaml_reference.md
+++ b/docs/yaml_reference.md
@@ -161,7 +161,7 @@ This example demonstrates multiple controls with custom widths and global contro
 
 ```yaml
 dashboard:
-  title: "Application Monitoring Dashboard"
+  name: "Application Monitoring Dashboard"
   description: "Dashboard with interactive controls."
   data_view: "logs-*" # Default data view for panels
   settings:

--- a/fixture-generator/README.md
+++ b/fixture-generator/README.md
@@ -209,7 +209,7 @@ docker run -v $(pwd)/output:/tool/output fixture-gen:8.15 node examples/metric-b
 
 The Dockerfile:
 
-1. Installs Node.js 20.x (matches Kibana requirement)
+1. Installs Node.js 22.x (matches Kibana requirement)
 2. Clones and bootstraps Kibana (making `@kbn/*` packages available)
 3. Provides access to `LensConfigBuilder` from `@kbn/lens-embeddable-utils`
 4. Runs your generator scripts and exports JSON to `./output/`

--- a/src/dashboard_compiler/panels/markdown/markdown.md
+++ b/src/dashboard_compiler/panels/markdown/markdown.md
@@ -86,4 +86,4 @@ Markdown panels inherit from the [Base Panel Configuration](../base.md) and have
 ## Related Documentation
 
 * [Base Panel Configuration](../base.md)
-* [Dashboard Configuration](../dashboard/dashboard.md)
+* [Dashboard Configuration](../../dashboard/dashboard.md)

--- a/yaml_reference.md
+++ b/yaml_reference.md
@@ -1,22 +1,23 @@
 \n---\n\n<!-- Source: src/dashboard_compiler/dashboard/dashboard.md -->\n\n# Dashboard Configuration
 
-The `dashboard` object is the root element in your YAML configuration file. It defines the overall structure, content, and global settings for a Kibana dashboard.
+The `dashboards` array is the root element in your YAML configuration file. Each dashboard defines the overall structure, content, and global settings for a Kibana dashboard.
 
 ## Minimal Configuration Example
 
 A minimal dashboard requires a `name` and at least one panel.
 
 ```yaml
-dashboard:
-  name: "Simple Log Dashboard"
-  panels:
-    - type: markdown # Assuming a markdown panel type exists
-      content: "Welcome to the dashboard!"
-      grid:
-        x: 0
-        y: 0
-        w: 6
-        h: 3
+dashboards:
+  -
+    name: "Simple Log Dashboard"
+    panels:
+      - type: markdown
+        content: "Welcome to the dashboard!"
+        grid:
+          x: 0
+          y: 0
+          w: 6
+          h: 3
 ```
 
 ## Complex Configuration Example
@@ -24,53 +25,57 @@ dashboard:
 This example showcases a dashboard with various settings, a default data view, a global query, filters, controls, and multiple panels.
 
 ```yaml
-dashboard:
-  name: "Comprehensive Application Overview"
-  id: "app-overview-001"
-  description: "An overview of application performance and logs, with interactive filtering."
-  data_view: "production-logs-*" # Default data view for all items unless overridden
-  settings:
-    margins: true
-    titles: true
-    sync:
-      cursor: true
-      tooltips: true
-      colors: false # Use distinct color palettes per panel
+dashboards:
+  -
+    name: "Comprehensive Application Overview"
+    id: "app-overview-001"
+    description: "An overview of application performance and logs, with interactive filtering."
+    data_view: "production-logs-*" # Default data view for all items unless overridden
+    settings:
+      margins: true
+      titles: true
+      sync:
+        cursor: true
+        tooltips: true
+        colors: false # Use distinct color palettes per panel
+      controls:
+        label_position: "above"
+        chain_controls: true
+    query:
+      kql: "NOT response_code:500" # Global KQL query
+    filters:
+      - field: "geo.country_iso_code"
+        equals: "US"
+      - field: "service.environment"
+        in_list: ["production", "staging"]
     controls:
-      label_position: "above"
-      chain_controls: true
-  query:
-    kql: "NOT response_code:500" # Global KQL query
-  filters:
-    - field: "geo.country_iso_code"
-      equals: "US"
-    - field: "service.environment"
-      is_one_of: ["production", "staging"]
-  controls:
-    - type: options
-      label: "Filter by Region"
-      data_view: "user-sessions-*"
-      field: "user.geo.region_name"
-      width: "medium"
-  panels:
-    - type: markdown
-      content: "### Key Performance Indicators"
-      grid: { x: 0, y: 0, w: 12, h: 2 }
-    - type: lens_metric # Assuming a lens metric panel type
-      title: "Total Requests"
-      data_view: "apm-traces-*"
-      metrics:
-        - type: count
-      grid: { x: 0, y: 2, w: 4, h: 4 }
-    - type: lens_bar_chart # Assuming a lens bar chart panel type
-      title: "Requests by Response Code"
-      data_view: "apm-traces-*"
-      series_type: "bar"
-      x_axis:
-        field: "http.response.status_code"
-      metrics:
-        - type: count
-      grid: { x: 4, y: 2, w: 8, h: 4 }
+      - type: options
+        label: "Filter by Region"
+        data_view: "user-sessions-*"
+        field: "user.geo.region_name"
+        width: "medium"
+    panels:
+      - type: markdown
+        content: "### Key Performance Indicators"
+        grid: { x: 0, y: 0, w: 12, h: 2 }
+      - type: lens
+        title: "Total Requests"
+        data_view: "apm-traces-*"
+        chart:
+          type: metric
+          metrics:
+            - type: count
+        grid: { x: 0, y: 2, w: 4, h: 4 }
+      - type: lens
+        title: "Requests by Response Code"
+        data_view: "apm-traces-*"
+        chart:
+          type: bar
+          x_axis:
+            field: "http.response.status_code"
+          metrics:
+            - type: count
+        grid: { x: 4, y: 2, w: 8, h: 4 }
 ```
 
 ## Full Configuration Options
@@ -128,32 +133,32 @@ While primarily declarative, the underlying Pydantic models for `Dashboard` supp
 * [Panels Overview](../panels/base.md)
 \n\n\n---\n\n<!-- Source: src/dashboard_compiler/controls/config.md -->\n\n# Controls Configuration
 
-Controls are interactive elements that can be added to a dashboard, allowing users to filter data or adjust visualization settings dynamically. They are defined as a list of control objects within the `controls` field of the main `dashboard` configuration. Global behavior of controls can be managed via the `settings.controls` object.
+Controls are interactive elements that can be added to a dashboard, allowing users to filter data or adjust visualization settings dynamically. They are defined as a list of control objects within each dashboard's `controls` field in the `dashboards:` array. Global behavior of controls can be managed via the `settings.controls` object.
 
 ## Minimal Configuration Examples
 
 Here's a minimal example of an `options` list control:
 
 ```yaml
-dashboard:
-  # ... other dashboard configurations
-  controls:
-    - type: options
-      label: "Filter by Status"
-      data_view: "your-data-view-id" # Replace with your data view ID or title
-      field: "status.keyword"      # Replace with the field to filter on
+dashboards:
+  -
+    controls:
+      - type: options
+        label: "Filter by Status"
+        data_view: "your-data-view-id" # Replace with your data view ID or title
+        field: "status.keyword"      # Replace with the field to filter on
 ```
 
 Here's a minimal example of a `range` slider control:
 
 ```yaml
-dashboard:
-  # ... other dashboard configurations
-  controls:
-    - type: range
-      label: "Response Time (ms)"
-      data_view: "your-data-view-id" # Replace with your data view ID or title
-      field: "response.time"       # Replace with the numeric field
+dashboards:
+  -
+    controls:
+      - type: range
+        label: "Response Time (ms)"
+        data_view: "your-data-view-id" # Replace with your data view ID or title
+        field: "response.time"       # Replace with the numeric field
 ```
 
 ## Complex Configuration Example
@@ -161,38 +166,39 @@ dashboard:
 This example demonstrates multiple controls with custom widths and global control settings:
 
 ```yaml
-dashboard:
-  title: "Application Monitoring Dashboard"
-  description: "Dashboard with interactive controls."
-  data_view: "logs-*" # Default data view for panels
-  settings:
+dashboards:
+  -
+    name: "Application Monitoring Dashboard"
+    description: "Dashboard with interactive controls."
+    data_view: "logs-*" # Default data view for panels
+    settings:
+      controls:
+        label_position: "above"
+        chain_controls: true
+        click_to_apply: false
     controls:
-      label_position: "above"
-      chain_controls: true
-      click_to_apply: false
-  controls:
-    - type: options
-      label: "Service Name"
-      id: "service_filter"
-      width: "medium"
-      data_view: "apm-*"
-      field: "service.name"
-      singular: false
-      match_technique: "contains"
-      preselected: ["checkout-service"]
-    - type: range
-      label: "CPU Usage (%)"
-      id: "cpu_range_filter"
-      width: "large"
-      data_view: "metrics-*"
-      field: "system.cpu.user.pct"
-      step: 0.05
-    - type: time
-      label: "Custom Time Slice"
-      id: "time_slice_control"
-      width: "small"
-      start_offset: 0.1  # 10% from the start of the global time range
-      end_offset: 0.9    # 90% from the start of the global time range
+      - type: options
+        label: "Service Name"
+        id: "service_filter"
+        width: "medium"
+        data_view: "apm-*"
+        field: "service.name"
+        singular: false
+        match_technique: "contains"
+        preselected: ["checkout-service"]
+      - type: range
+        label: "CPU Usage (%)"
+        id: "cpu_range_filter"
+        width: "large"
+        data_view: "metrics-*"
+        field: "system.cpu.user.pct"
+        step: 0.05
+      - type: time
+        label: "Custom Time Slice"
+        id: "time_slice_control"
+        width: "small"
+        start_offset: 0.1  # 10% from the start of the global time range
+        end_offset: 0.9    # 90% from the start of the global time range
 ```
 
 ## Full Configuration Options
@@ -1774,7 +1780,6 @@ A metric that is defined in the ESQL query.
     ```yaml
     - field: total_requests
       label: Total Requests from ESQL
-
 \n\n\n---\n\n<!-- Source: src/dashboard_compiler/panels/charts/metric/config.md -->\n\n# Metric Chart Panel Configuration
 
 The Metric chart panel displays a single value or a small set of key metrics, often used for KPIs or summary statistics.
@@ -1807,8 +1812,8 @@ dashboard:
 
 ## Related
 
-* [Base Panel Configuration](../../base.md)
-* [Dashboard Configuration](../../../dashboard/dashboard.md)
+- [Base Panel Configuration](../../base.md)
+- [Dashboard Configuration](../../../dashboard/dashboard.md)
 \n\n\n---\n\n<!-- Source: src/dashboard_compiler/panels/charts/pie/config.md -->\n\n# Pie Chart Panel Configuration
 
 The Pie chart panel visualizes data as a pie or donut chart, useful for showing proportions of a whole.
@@ -1845,8 +1850,8 @@ dashboard:
 
 ## Related
 
-* [Base Panel Configuration](../../base.md)
-* [Dashboard Configuration](../../../dashboard/dashboard.md)
+- [Base Panel Configuration](../../base.md)
+- [Dashboard Configuration](../../../dashboard/dashboard.md)
 \n\n\n---\n\n<!-- Source: src/dashboard_compiler/panels/images/image.md -->\n\n# Image Panel Configuration
 
 The `image` panel type is used to display an image directly on your dashboard. This can be useful for branding, diagrams, or other visual elements.
@@ -2161,7 +2166,7 @@ Markdown panels inherit from the [Base Panel Configuration](../base.md) and have
 ## Related Documentation
 
 * [Base Panel Configuration](../base.md)
-* [Dashboard Configuration](../dashboard/dashboard.md)
+* [Dashboard Configuration](../../dashboard/dashboard.md)
 \n\n\n---\n\n<!-- Source: src/dashboard_compiler/panels/search/search.md -->\n\n# Search Panel Configuration
 
 The `search` panel type is used to embed the results of a pre-existing, saved Kibana search directly onto your dashboard. This allows you to display dynamic log views, event lists, or any other data set defined by a saved search in Discover.


### PR DESCRIPTION
## Summary

This PR fixes documentation issues identified in the code review for issue #18.

### Changes

1. **Dashboard Field Name Correction** (Critical)
   - Changed `dashboard.title:` to `dashboard.name:` in all documentation examples
   - The code uses `name` as the field (src/dashboard_compiler/dashboard/config.py:43)
   - Fixed in: README.md, docs/index.md, docs/quickstart.md, docs/yaml_reference.md

2. **Node.js Version Consistency** (Medium)
   - Updated fixture-generator/README.md to specify Node.js 22.x instead of 20.x
   - Matches version in docs/kibana-fixture-generator-guide.md and GHCR.md

3. **Fixed Broken Link** (Low)
   - Corrected relative path in src/dashboard_compiler/panels/markdown/markdown.md
   - Changed `../dashboard/dashboard.md` to `../../dashboard/dashboard.md`

4. **Regenerated Documentation**
   - Ran `scripts/compile_docs.py` to regenerate yaml_reference.md from updated source files

### Verification

- ✅ All 104 tests passed
- ✅ Ruff linting passed
- ✅ Examples now use correct field names

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-18-20251221-2353) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20417695033