### PR TITLE
fix: install Node.js and markdownlint-cli in CI setup action

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -10,9 +10,18 @@ runs:
       with:
         python-version: '3.12'
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
     - name: Install UV
       uses: astral-sh/setup-uv@v7
 
     - name: Install dependencies
       shell: bash
       run: uv sync --group dev
+
+    - name: Install markdownlint-cli
+      shell: bash
+      run: npm install -g markdownlint-cli


### PR DESCRIPTION
## Summary

This PR fixes issue #184 by ensuring markdown validation runs in all CI workflows and Claude agent workflows.

## Changes

- Added Node.js 20 setup to `.github/actions/setup-python-env/action.yml`
- Added global installation of `markdownlint-cli` in the setup action

## Why

The markdown linting feature was added in PR #78, but the CI/CD workflows were not updated to install the required `markdownlint-cli` tool. This caused `make check` to skip markdown linting with a warning.

By adding the installation to the shared `setup-python-env` action, all workflows that use this action will automatically have markdownlint available.

## Testing

After merging, verify that:
- CI workflows pass with markdown linting enabled
- Claude agents can successfully run `make check` without warnings

Fixes #184

---

Generated with [Claude Code](https://claude.ai/code)