### PR TITLE
docs: remove unnecessary type arguments from Python examples

### DIFF
--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -28,7 +28,6 @@ dashboard = Dashboard(
 
 # Add a markdown panel
 panel = MarkdownPanel(
-    type='markdown',
     grid=Grid(x=0, y=0, w=24, h=15),
     content='# Hello from Python!',
 )
@@ -123,13 +122,11 @@ metrics_config = [
 
 for i, metric in enumerate(metrics_config):
     chart = LensMetricChart(
-        type='metric',
         data_view='metrics-*',
         primary=LensOtherAggregatedMetric(aggregation='average', field=metric['field']),
     )
 
     panel = LensPanel(
-        type='charts',
         title=metric['name'],
         grid=Grid(
             x=(i % 3) * 16,  # 3 columns
@@ -149,13 +146,11 @@ for i, metric in enumerate(metrics_config):
 def create_metric_panel(title: str, field: str, x: int, y: int) -> LensPanel:
     """Helper function to create a standard metric panel."""
     chart = LensMetricChart(
-        type='metric',
         data_view='logs-*',
         primary=LensOtherAggregatedMetric(aggregation='average', field=field),
     )
 
     return LensPanel(
-        type='charts',
         title=title,
         grid=Grid(x=x, y=y, w=24, h=15),
         chart=chart,

--- a/src/dashboard_compiler/panels/charts/metric/config.md
+++ b/src/dashboard_compiler/panels/charts/metric/config.md
@@ -44,13 +44,11 @@ from dashboard_compiler.panels.config import Grid
 
 # Simple count metric
 count_chart = LensMetricChart(
-    type='metric',
     data_view='logs-*',
     primary=LensCountAggregatedMetric(aggregation='count'),
 )
 
 panel = LensPanel(
-    type='charts',
     title='Total Documents',
     grid=Grid(x=0, y=0, w=24, h=15),
     chart=count_chart,
@@ -69,13 +67,11 @@ from dashboard_compiler.panels.config import Grid
 
 # Average metric with field
 avg_chart = LensMetricChart(
-    type='metric',
     data_view='logs-*',
     primary=LensOtherAggregatedMetric(aggregation='average', field='response_time'),
 )
 
 panel = LensPanel(
-    type='charts',
     title='Avg Response Time',
     grid=Grid(x=0, y=0, w=24, h=15),
     chart=avg_chart,

--- a/src/dashboard_compiler/panels/charts/pie/config.md
+++ b/src/dashboard_compiler/panels/charts/pie/config.md
@@ -48,14 +48,12 @@ from dashboard_compiler.panels.charts.pie.config import LensPieChart
 from dashboard_compiler.panels.config import Grid
 
 pie_chart = LensPieChart(
-    type='pie',
     data_view='logs-*',
     slice_by=[LensTopValuesDimension(field='status')],
     metric=LensCountAggregatedMetric(aggregation='count'),
 )
 
 panel = LensPanel(
-    type='charts',
     title='Status Distribution',
     grid=Grid(x=0, y=0, w=24, h=15),
     chart=pie_chart,

--- a/src/dashboard_compiler/panels/charts/xy/config.md
+++ b/src/dashboard_compiler/panels/charts/xy/config.md
@@ -48,7 +48,6 @@ from dashboard_compiler.panels.config import Grid
 
 # Time series line chart
 line_chart = LensLineChart(
-    type='line',
     data_view='logs-*',
     dimensions=[LensDateHistogramDimension(field='@timestamp')],
     breakdown=None,
@@ -56,7 +55,6 @@ line_chart = LensLineChart(
 )
 
 panel = LensPanel(
-    type='charts',
     title='Documents Over Time',
     grid=Grid(x=0, y=0, w=48, h=20),
     chart=line_chart,

--- a/src/dashboard_compiler/panels/images/image.md
+++ b/src/dashboard_compiler/panels/images/image.md
@@ -84,7 +84,6 @@ from dashboard_compiler.panels.config import Grid
 from dashboard_compiler.panels.images.config import ImagePanel
 
 panel = ImagePanel(
-    type='image',
     grid=Grid(x=0, y=0, w=24, h=20),
     from_url='https://example.com/logo.png',
 )

--- a/src/dashboard_compiler/panels/links/links.md
+++ b/src/dashboard_compiler/panels/links/links.md
@@ -144,7 +144,6 @@ from dashboard_compiler.panels.config import Grid
 from dashboard_compiler.panels.links.config import LinksPanel, UrlLink
 
 panel = LinksPanel(
-    type='links',
     grid=Grid(x=0, y=0, w=24, h=10),
     links=[
         UrlLink(
@@ -166,7 +165,6 @@ from dashboard_compiler.panels.config import Grid
 from dashboard_compiler.panels.links.config import LinksPanel, UrlLink
 
 panel = LinksPanel(
-    type='links',
     grid=Grid(x=0, y=0, w=24, h=10),
     links=[],
 )

--- a/src/dashboard_compiler/panels/markdown/markdown.md
+++ b/src/dashboard_compiler/panels/markdown/markdown.md
@@ -92,7 +92,6 @@ from dashboard_compiler.panels.config import Grid
 from dashboard_compiler.panels.markdown.config import MarkdownPanel
 
 panel = MarkdownPanel(
-    type='markdown',
     grid=Grid(x=0, y=0, w=24, h=15),
     content="""
 # Dashboard Title

--- a/src/dashboard_compiler/panels/search/search.md
+++ b/src/dashboard_compiler/panels/search/search.md
@@ -76,7 +76,6 @@ from dashboard_compiler.panels.config import Grid
 from dashboard_compiler.panels.search.config import SearchPanel
 
 panel = SearchPanel(
-    type='search',
     grid=Grid(x=0, y=0, w=48, h=20),
     saved_search_id='my-saved-search',
 )


### PR DESCRIPTION
## Summary

Removes redundant `type` arguments from panel and chart constructor examples in documentation. All panel and chart classes have default values for their `type` fields, making these arguments unnecessary.

## Changes

- Cleaned up 18 occurrences across 8 documentation files
- Examples are now more concise and demonstrate idiomatic Python usage
- All tests pass

Fixes #292

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed Python API documentation examples across all panel types (Markdown, Metric, Pie, Charts, Image, Links, and Search) by removing redundant explicit type parameters from code snippets. Updated code samples now demonstrate cleaner, more concise usage patterns with automatic type inference, making it easier for developers to write simpler implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->