### PR TITLE
docs: Reorganize documentation site with three-tier navigation

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,89 @@
+# Complete Examples
+
+This section provides real-world YAML dashboard examples demonstrating various features and capabilities of the Dashboard Compiler.
+
+## Available Examples
+
+### [Controls Example](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/controls-example.yaml)
+
+Demonstrates the use of dashboard controls including:
+
+- Options list controls for filtering
+- Range slider controls
+- Time slider controls
+- Control chaining and dependencies
+- Custom label positions
+
+**Use this when:** You need interactive filtering capabilities on your dashboard.
+
+### [Dimensions Example](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/dimensions-example.yaml)
+
+Shows how to configure dimensions in Lens visualizations:
+
+- Multiple dimension types
+- Custom formatting options
+- Breakdown configurations
+- Top values and other bucketing strategies
+
+**Use this when:** You're building complex charts with multiple breakdowns and groupings.
+
+### [Filters Example](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/filters-example.yaml)
+
+Comprehensive filter demonstrations including:
+
+- Field existence filters
+- Phrase and phrase list filters
+- Range filters (numeric and date)
+- Custom DSL filters
+- Combined filters with AND/OR/NOT operators
+- Panel-level and dashboard-level filters
+
+**Use this when:** You need to pre-filter data or provide context-specific views.
+
+### [Multi-Panel Showcase](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/multi-panel-showcase.yaml)
+
+A complete dashboard featuring multiple panel types:
+
+- Markdown panels for documentation
+- Metric charts for KPIs
+- Pie charts for distributions
+- XY charts for trends
+- Image panels
+- Links panels for navigation
+- Grid layout examples
+
+**Use this when:** You want to see how different panel types work together in a single dashboard.
+
+### [Navigation Example](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/navigation-example.yaml)
+
+Demonstrates dashboard navigation features:
+
+- Links panels with external and internal navigation
+- Dashboard linking patterns
+- URL parameter passing
+- Navigation best practices
+
+**Use this when:** You're building a suite of interconnected dashboards.
+
+## Viewing Example Source Code
+
+All example files are located in the `docs/examples/` directory of the repository. You can:
+
+1. **Browse on GitHub:** Click any example link above to view the YAML source
+2. **Clone locally:** Download the repository to experiment with examples
+3. **Compile examples:** Run `kb-dashboard compile --input-dir docs/examples --output-dir output` to generate NDJSON files
+
+## Using Examples as Templates
+
+To use an example as a starting point for your own dashboard:
+
+1. Copy the example YAML file to your `inputs/` directory
+2. Modify the dashboard name, description, and ID
+3. Adjust panels, filters, and controls to match your data views
+4. Compile and upload to Kibana
+
+## Related Documentation
+
+- [YAML Reference](../yaml_reference.md) - Complete schema documentation
+- [Dashboard Configuration](../dashboard/dashboard.md) - Dashboard-level settings
+- [Panel Types](../panels/base.md) - Available panel types and configurations

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,15 +82,42 @@ kb-dashboard compile \
 The `--upload` flag will automatically open your dashboard in the browser upon
 successful upload.
 
-## Documentation
+## Where to Start
 
-- **[Quickstart Guide](quickstart.md)** – Step-by-step guide for creating your
-  first dashboard
-- **[Architecture](architecture.md)** – Technical design and data flow overview
-- **[YAML Reference](yaml_reference.md)** – Complete schema documentation for
-  all dashboard elements
-- **[Contributing Guide](https://github.com/strawgate/kb-yaml-to-lens/blob/main/CONTRIBUTING.md)** – How to contribute and add new
-  capabilities
+- **New to kb-yaml-to-lens?** → Start with the [Quickstart Guide](quickstart.md)
+- **Building dashboards?** → Browse the [User Guide](#user-guide) for YAML reference and panel documentation
+- **Contributing or extending?** → Check the [Developer Guide](#developer-guide) for architecture and API documentation
+
+## Documentation Sections
+
+### Getting Started
+
+New users should begin here to learn the basics:
+
+- **[Quickstart Guide](quickstart.md)** – Step-by-step guide for creating your first dashboard
+- **[CLI Reference](CLI.md)** – Command-line interface documentation
+
+### User Guide
+
+Reference documentation for building dashboards in YAML:
+
+- **[YAML Reference](yaml_reference.md)** – Complete schema documentation for all dashboard elements
+- **[Dashboard Configuration](dashboard/dashboard.md)** – Dashboard-level settings and options
+- **[Panel Types](panels/base.md)** – Available panel types (Markdown, Charts, Images, Links, etc.)
+- **[Dashboard Controls](controls/config.md)** – Interactive filtering controls
+- **[Filters & Queries](filters/config.md)** – Data filtering and query configuration
+- **[Complete Examples](examples/index.md)** – Real-world YAML dashboard examples
+
+### Developer Guide
+
+Advanced documentation for contributors and programmatic usage:
+
+- **[Architecture Overview](architecture.md)** – Technical design and data flow
+- **[Programmatic Usage](programmatic-usage.md)** – Using the Python API directly
+- **[API Reference](api/index.md)** – Auto-generated Python API documentation
+- **[Contributing Guide](../CONTRIBUTING.md)** – How to contribute and add new capabilities
+- **[Kibana Architecture Reference](kibana-architecture.md)** – Understanding Kibana's internal structure
+- **[Fixture Generator Guide](kibana-fixture-generator-guide.md)** – Generating test fixtures from live Kibana instances
 
 ## Requirements
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,26 +79,45 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Getting Started: quickstart.md
-  - Programmatic Usage: programmatic-usage.md
-  - Architecture: architecture.md
-  - YAML Reference: yaml_reference.md
-  - CLI Guide: CLI.md
-  - Contributing: ../CONTRIBUTING.md
-  - Guides:
-      - Kibana Fixture Generator: kibana-fixture-generator-guide.md
-  - API Reference:
-      - api/index.md
-      - Dashboard: api/dashboard.md
-      - Panels: api/panels.md
-      - Controls: api/controls.md
-      - Filters: api/filters.md
-      - Queries: api/queries.md
-  - Panel Configuration:
-      - Markdown Panel: panels/markdown.md
-      - Image Panel: panels/image.md
-      - Links Panel: panels/links.md
-      - Search Panel: panels/search.md
-      - Metric Chart: panels/metric.md
-      - Pie Chart: panels/pie.md
-      - XY Chart: panels/xy.md
+
+  # TIER 1: Getting Started (New Users)
+  - Getting Started:
+      - Quickstart: quickstart.md
+      - CLI Reference: CLI.md
+
+  # TIER 2: User Guide (Building Dashboards)
+  - User Guide:
+      - YAML Reference: yaml_reference.md
+      - Dashboard Configuration: dashboard/dashboard.md
+      - Panel Types:
+          - Overview: panels/base.md
+          - Markdown Panels: panels/markdown.md
+          - Chart Panels:
+              - Metric Charts: panels/metric.md
+              - Pie Charts: panels/pie.md
+              - XY Charts: panels/xy.md
+          - Special Panels:
+              - Image Panels: panels/image.md
+              - Links Panels: panels/links.md
+              - Search Panels: panels/search.md
+      - Dashboard Controls: controls/config.md
+      - Filters & Queries:
+          - Filters: filters/config.md
+          - Queries: queries/config.md
+      - Complete Examples: examples/index.md
+
+  # TIER 3: Developer Resources (Advanced/Contributors)
+  - Developer Guide:
+      - Architecture Overview: architecture.md
+      - Programmatic Usage: programmatic-usage.md
+      - API Reference:
+          - api/index.md
+          - Dashboard API: api/dashboard.md
+          - Panels API: api/panels.md
+          - Controls API: api/controls.md
+          - Filters API: api/filters.md
+          - Queries API: api/queries.md
+      - Contributing: ../CONTRIBUTING.md
+      - Advanced Topics:
+          - Kibana Architecture Reference: kibana-architecture.md
+          - Fixture Generator Guide: kibana-fixture-generator-guide.md


### PR DESCRIPTION
Implements a clearer information architecture for the documentation site with three distinct sections:

1. **Getting Started** - For new users learning the basics
2. **User Guide** - Reference docs for building dashboards in YAML
3. **Developer Guide** - Advanced docs for contributors and API users

## Changes

- Reorganized `mkdocs.yml` navigation into three clear tiers
- Created `docs/examples/index.md` with descriptions of all examples
- Enhanced `docs/index.md` with clear user pathways
- Grouped related documentation (panels, controls, filters, queries)
- Separated user-facing YAML docs from developer API docs

Fixes #355


Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20584677216) | [Branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-355-20251229-2308