### PR TITLE
fix: update broken documentation links

### DIFF
--- a/docs/api/panels.md
+++ b/docs/api/panels.md
@@ -18,7 +18,7 @@ Display rich text content using markdown syntax.
     options:
       show_source: true
 
-For configuration details and examples, see the [Markdown Panel Configuration](../../src/dashboard_compiler/panels/markdown/markdown.md).
+For configuration details and examples, see the [Markdown Panel Configuration](../panels/markdown.md).
 
 ## Links Panels
 
@@ -30,7 +30,7 @@ Display collections of clickable links.
     options:
       show_source: true
 
-For configuration details and examples, see the [Links Panel Configuration](../../src/dashboard_compiler/panels/links/links.md).
+For configuration details and examples, see the [Links Panel Configuration](../panels/links.md).
 
 ## Image Panels
 
@@ -42,7 +42,7 @@ Embed images in your dashboard.
     options:
       show_source: true
 
-For configuration details and examples, see the [Image Panel Configuration](../../src/dashboard_compiler/panels/images/image.md).
+For configuration details and examples, see the [Image Panel Configuration](../panels/image.md).
 
 ## Search Panels
 
@@ -54,7 +54,7 @@ Display search results from Elasticsearch.
     options:
       show_source: true
 
-For configuration details and examples, see the [Search Panel Configuration](../../src/dashboard_compiler/panels/search/search.md).
+For configuration details and examples, see the [Search Panel Configuration](../panels/search.md).
 
 ## Lens Panel
 

--- a/docs/panels/esql.md
+++ b/docs/panels/esql.md
@@ -82,7 +82,7 @@ dashboards:
 
 ### ESQL Panel (`type: charts` with an `esql` field)
 
-This is the main object for an ESQL-based visualization. It inherits from the [Base Panel Configuration](./base.md). The presence of the `esql` field distinguishes it from a Lens panel.
+This is the main object for an ESQL-based visualization. It inherits from the [Base Panel Configuration](base.md). The presence of the `esql` field distinguishes it from a Lens panel.
 
 | YAML Key | Data Type | Description | Kibana Default | Required |
 | -------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------------------- | -------- |
@@ -91,8 +91,8 @@ This is the main object for an ESQL-based visualization. It inherits from the [B
 | `title` | `string` | The title displayed on the panel header. Inherited from BasePanel. | `""` (empty string) | No |
 | `hide_title` | `boolean` | If `true`, the panel title will be hidden. Inherited from BasePanel. | `false` | No |
 | `description` | `string` | A brief description of the panel. Inherited from BasePanel. | `""` (empty string, if `None`) | No |
-| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](./base.md#grid-object-configuration). | N/A | Yes |
-| `esql` | `string` or `ESQLQuery` object | The ESQL query string. See [Queries Documentation](../../queries/config.md#esql-query). | N/A | Yes |
+| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](base.md#grid-object-configuration). | N/A | Yes |
+| `esql` | `string` or `ESQLQuery` object | The ESQL query string. See [Queries Documentation](../queries/config.md#esql-query). | N/A | Yes |
 | `chart` | `ESQLChartTypes` object | Defines the actual ESQL visualization configuration. This will be one of [ESQL Metric Chart](#esql-metric-chart-charttype-metric) or [ESQL Pie Chart](#esql-pie-chart-charttype-pie). | N/A | Yes |
 
 ---
@@ -213,7 +213,7 @@ ESQL Pie Charts share the same formatting options for appearance, titles/text, l
 
 ## Related Documentation
 
-* [Base Panel Configuration](./base.md)
+* [Base Panel Configuration](base.md)
 * [Dashboard Configuration](../dashboard/dashboard.md)
-* [Queries Configuration](../../queries/config.md#esql-query)
+* [Queries Configuration](../queries/config.md#esql-query)
 * Elasticsearch ESQL Reference (external)

--- a/docs/panels/lens.md
+++ b/docs/panels/lens.md
@@ -78,7 +78,7 @@ dashboards:
 
 ### Lens Panel (`type: charts`)
 
-This is the main object for a Lens-based visualization. It inherits from the [Base Panel Configuration](./base.md).
+This is the main object for a Lens-based visualization. It inherits from the [Base Panel Configuration](base.md).
 
 | YAML Key | Data Type | Description | Kibana Default | Required |
 | -------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------------------- | -------- |
@@ -87,9 +87,9 @@ This is the main object for a Lens-based visualization. It inherits from the [Ba
 | `title` | `string` | The title displayed on the panel header. Inherited from BasePanel. | `""` (empty string) | No |
 | `hide_title` | `boolean` | If `true`, the panel title will be hidden. Inherited from BasePanel. | `false` | No |
 | `description` | `string` | A brief description of the panel. Inherited from BasePanel. | `""` (empty string, if `None`) | No |
-| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](./base.md#grid-object-configuration). | N/A | Yes |
-| `query` | `LegacyQueryTypes` object (KQL or Lucene) | A panel-specific query to filter data for this Lens visualization. See [Queries Documentation](../../queries/config.md). | `None` (uses dashboard query) | No |
-| `filters` | `list of FilterTypes` | A list of panel-specific filters. See [Filters Documentation](../../filters/config.md). | `[]` (empty list) | No |
+| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](base.md#grid-object-configuration). | N/A | Yes |
+| `query` | `LegacyQueryTypes` object (KQL or Lucene) | A panel-specific query to filter data for this Lens visualization. See [Queries Documentation](../queries/config.md). | `None` (uses dashboard query) | No |
+| `filters` | `list of FilterTypes` | A list of panel-specific filters. See [Filters Documentation](../filters/config.md). | `[]` (empty list) | No |
 | `chart` | `LensChartTypes` object | Defines the actual Lens visualization configuration. This will be one of [Lens Metric Chart](#lens-metric-chart-charttype-metric) or [Lens Pie Chart](#lens-pie-chart-charttype-pie). | N/A | Yes |
 | `layers` | `list of MultiLayerChartTypes` | For multi-layer charts (e.g., multiple pie charts on one panel). *Currently, only `LensPieChart` is supported as a multi-layer type.* | `None` | No |
 
@@ -401,7 +401,7 @@ These objects are used within the `LensPieChart` configuration.
 
 ## Related Documentation
 
-* [Base Panel Configuration](./base.md)
+* [Base Panel Configuration](base.md)
 * [Dashboard Configuration](../dashboard/dashboard.md)
-* [Queries Configuration](../../queries/config.md)
-* [Filters Configuration](../../filters/config.md)
+* [Queries Configuration](../queries/config.md)
+* [Filters Configuration](../filters/config.md)

--- a/docs/panels/tagcloud.md
+++ b/docs/panels/tagcloud.md
@@ -115,8 +115,7 @@ dashboards:
 
 ## Related
 
-- [Base Chart Configuration](../base/config.md)
-- [Lens Dimensions](../lens/dimensions/config.md)
-- [Lens Metrics](../lens/metrics/config.md)
-- [ES|QL Dimensions](../esql/columns/config.md)
-- [Dashboard Configuration](../../../dashboard/config.md)
+- [Base Panel Configuration](base.md)
+- [Lens Panel Configuration](lens.md) (see sections on Dimensions and Metrics)
+- [ESQL Panel Configuration](esql.md) (see section on ESQL Columns)
+- [Dashboard Configuration](../dashboard/dashboard.md)


### PR DESCRIPTION
Fixed 21 broken documentation links across 4 files.

## Changes
- Fixed 4 broken links in docs/api/panels.md (panel type references)
- Fixed 5 broken links in docs/panels/esql.md (base config and queries)
- Fixed 6 broken links in docs/panels/lens.md (base config, queries, and filters)
- Fixed 6 broken links in docs/panels/tagcloud.md (related documentation)

All links now use correct relative paths consistent with the documentation structure after the symlink changes from PR #341.

Fixes #375

🤖 Generated with [Claude Code](https://claude.ai/code)