### PR TITLE
fix: move Aerospike dashboards to examples and fix schema issues

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -25,4 +25,3 @@ ignore: |
   htmlcov/
   .git/
   vscode-extension/node_modules/
-  docs/examples/

--- a/docs/examples/aerospike/namespace-metrics.yaml
+++ b/docs/examples/aerospike/namespace-metrics.yaml
@@ -139,4 +139,4 @@ dashboards:
             - aggregation: min
               label: Transactions per Second
               field: metrics.aerospike.namespace.transaction.count
-          # format: {id: "number", params: {decimals: 2}} # Not directly supported in YAML schema
+              # format: {id: "number", params: {decimals: 2}} # Not directly supported in YAML schema

--- a/docs/examples/aerospike/node-metrics.yaml
+++ b/docs/examples/aerospike/node-metrics.yaml
@@ -1,8 +1,16 @@
 ---
 dashboards:
-  - id: 4d5b8a67-c5d9-478c-8128-e09cccc7f8ef
-    name: '[Metrics Aerospike] Overview'
+  - id: 36bd5b4a-9c5b-4377-827d-f2e64d860f60
+    name: '[Metrics Aerospike] Node Metrics'
     description: ''
+    controls:
+      - type: options
+        id: 28b2de58-2df1-404b-869b-5c056630a213
+        label: Aerospike Node
+        width: medium
+        data_view: metrics-*
+        field: aerospike.node.name
+        match_technique: contains
     panels:
       - grid: {x: 0, y: 0, w: 48, h: 2}
         links:
@@ -14,8 +22,12 @@ dashboards:
               dashboard: 36bd5b4a-9c5b-4377-827d-f2e64d860f60
             - label: Namespace Metrics
               dashboard: c9484395-aa2b-43c4-84ad-12a7feb8c7d1
+      - grid: {x: 0, y: 2, w: 48, h: 2}
+        markdown:
+          content: |
+            This dashboard is intended to be used with a single Aerospike node. Filter to a specific node before using this dashboard.
       - type: charts
-        grid: {x: 0, y: 2, w: 10, h: 3}
+        grid: {x: 0, y: 4, w: 7, h: 5}
         filters:
           - field: data_stream.dataset
             equals: aerospikereceiver.otel
@@ -25,9 +37,21 @@ dashboards:
           primary:
             aggregation: unique_count
             field: aerospike.node.name
-            label: Aerospike Nodes
+            label: Selected Nodes
       - type: charts
-        grid: {x: 10, y: 2, w: 38, h: 9}
+        grid: {x: 0, y: 9, w: 10, h: 5}
+        filters:
+          - field: data_stream.dataset
+            equals: aerospikereceiver.otel
+        chart:
+          type: metric
+          data_view: metrics-*
+          primary:
+            aggregation: unique_count
+            field: aerospike.namespace
+            label: Aerospike Namespaces
+      - type: charts
+        grid: {x: 10, y: 4, w: 38, h: 9}
         filters:
           - field: data_stream.dataset
             equals: aerospikereceiver.otel
@@ -43,31 +67,17 @@ dashboards:
               label: Top 15 values of aerospike.node.name
               size: 15
               sort:
-                by: Free Memory  # Assuming alphabetical sort maps to _key
+                by: Free Memory
                 direction: asc
               other_bucket: true
               missing_bucket: false
-          primary:
+          metrics:
             - aggregation: min
               label: Free Memory
               field: aerospike.node.memory.free
-              # format: {id: "percent", params: {decimals: 0}} # Not directly supported in YAML schema
       - type: charts
-        grid: {x: 0, y: 5, w: 10, h: 3}
+        grid: {x: 10, y: 13, w: 17, h: 14}
         filters:
-          - field: data_stream.dataset
-            equals: aerospikereceiver.otel
-        chart:
-          type: metric
-          data_view: metrics-*
-          primary:
-            aggregation: unique_count
-            field: aerospike.namespace
-            label: Unique Namespaces
-      - type: charts
-        grid: {x: 27, y: 9, w: 38, h: 9}
-        filters:
-          - exists: aerospike.node.connection.open
           - field: data_stream.dataset
             equals: aerospikereceiver.otel
         chart:
@@ -79,13 +89,40 @@ dashboards:
               label: '@timestamp'
             - field: aerospike.node.name
               type: values
+              label: Top 15 values of aerospike.node.name
+              size: 15
+              sort:
+                by: Used Memory
+                direction: desc
+              other_bucket: true
+              missing_bucket: false
+          metrics:
+            - aggregation: min
+              label: Used Memory
+              field: aerospike.node.memory.used
+      - type: charts
+        grid: {x: 27, y: 13, w: 21, h: 14}
+        filters:
+          - exists: aerospike.node.connection.open
+          - field: data_stream.dataset
+            equals: aerospikereceiver.otel
+        chart:
+          type: line
+          data_view: metrics-*
+          dimensions:
+            - field: '@timestamp'
+              type: date_histogram
+              label: '@timestamp'
+            - field: attributes.type
+              type: values
+              label: Top 15 values of attributes.type
               size: 15
               sort:
                 by: Open Connections
                 direction: desc
               other_bucket: true
               missing_bucket: false
-          primary:
+          metrics:
             - aggregation: max
               field: aerospike.node.connection.open
               label: Open Connections

--- a/docs/examples/aerospike/overview.yaml
+++ b/docs/examples/aerospike/overview.yaml
@@ -1,16 +1,8 @@
 ---
 dashboards:
-  - id: 36bd5b4a-9c5b-4377-827d-f2e64d860f60
-    name: '[Metrics Aerospike] Node Metrics'
+  - id: 4d5b8a67-c5d9-478c-8128-e09cccc7f8ef
+    name: '[Metrics Aerospike] Overview'
     description: ''
-    controls:
-      - type: options
-        id: 28b2de58-2df1-404b-869b-5c056630a213
-        label: Aerospike Node
-        width: medium
-        data_view: metrics-*
-        field: aerospike.node.name
-        match_technique: contains
     panels:
       - grid: {x: 0, y: 0, w: 48, h: 2}
         links:
@@ -22,12 +14,8 @@ dashboards:
               dashboard: 36bd5b4a-9c5b-4377-827d-f2e64d860f60
             - label: Namespace Metrics
               dashboard: c9484395-aa2b-43c4-84ad-12a7feb8c7d1
-      - grid: {x: 0, y: 2, w: 48, h: 2}
-        markdown:
-          content: |
-            This dashboard is intended to be used with a single Aerospike node. Filter to a specific node before using this dashboard.
       - type: charts
-        grid: {x: 0, y: 4, w: 7, h: 5}
+        grid: {x: 0, y: 2, w: 10, h: 3}
         filters:
           - field: data_stream.dataset
             equals: aerospikereceiver.otel
@@ -37,19 +25,7 @@ dashboards:
           primary:
             aggregation: unique_count
             field: aerospike.node.name
-            label: Selected Nodes
-      - type: charts
-        grid: {x: 0, y: 9, w: 10, h: 5}
-        filters:
-          - field: data_stream.dataset
-            equals: aerospikereceiver.otel
-        chart:
-          type: metric
-          data_view: metrics-*
-          primary:
-            aggregation: unique_count
-            field: aerospike.namespace
-            label: Aerospike Namespaces
+            label: Aerospike Nodes
       - type: charts
         grid: {x: 10, y: 2, w: 38, h: 9}
         filters:
@@ -67,7 +43,7 @@ dashboards:
               label: Top 15 values of aerospike.node.name
               size: 15
               sort:
-                by: Free Memory
+                by: Free Memory  # Assuming alphabetical sort maps to _key
                 direction: asc
               other_bucket: true
               missing_bucket: false
@@ -75,33 +51,21 @@ dashboards:
             - aggregation: min
               label: Free Memory
               field: aerospike.node.memory.free
+              # format: {id: "percent", params: {decimals: 0}} # Not directly supported in YAML schema
       - type: charts
-        grid: {x: 10, y: 9, w: 17, h: 14}
+        grid: {x: 0, y: 5, w: 10, h: 3}
         filters:
           - field: data_stream.dataset
             equals: aerospikereceiver.otel
         chart:
-          type: line
+          type: metric
           data_view: metrics-*
-          dimensions:
-            - field: '@timestamp'
-              type: date_histogram
-              label: '@timestamp'
-            - field: aerospike.node.name
-              type: values
-              label: Top 15 values of aerospike.node.name
-              size: 15
-              sort:
-                by: Used Memory
-                direction: desc
-              other_bucket: true
-              missing_bucket: false
-          metrics:
-            - aggregation: min
-              label: Used Memory
-              field: aerospike.node.memory.used
+          primary:
+            aggregation: unique_count
+            field: aerospike.namespace
+            label: Unique Namespaces
       - type: charts
-        grid: {x: 27, y: 9, w: 21, h: 14}
+        grid: {x: 0, y: 11, w: 48, h: 9}
         filters:
           - exists: aerospike.node.connection.open
           - field: data_stream.dataset
@@ -113,9 +77,8 @@ dashboards:
             - field: '@timestamp'
               type: date_histogram
               label: '@timestamp'
-            - field: attributes.type
+            - field: aerospike.node.name
               type: values
-              label: Top 15 values of attributes.type
               size: 15
               sort:
                 by: Open Connections

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -65,6 +65,16 @@ Demonstrates dashboard navigation features:
 
 **Use this when:** You're building a suite of interconnected dashboards.
 
+### [Aerospike Monitoring Examples](https://github.com/strawgate/kb-yaml-to-lens/tree/main/docs/examples/aerospike/)
+
+Real-world monitoring dashboards for Aerospike database:
+
+- **Overview Dashboard** - Cluster-level metrics and node health
+- **Node Metrics** - Detailed per-node performance monitoring
+- **Namespace Metrics** - Namespace-level storage and query statistics
+
+**Use this when:** Monitoring Aerospike NoSQL database deployments.
+
 ## Viewing Example Source Code
 
 All example files are located in the `docs/examples/` directory of the repository. You can:

--- a/tests/test_example_dashboards.py
+++ b/tests/test_example_dashboards.py
@@ -1,0 +1,23 @@
+"""Test that example dashboards in docs/examples/ compile successfully."""
+
+from pathlib import Path
+
+import pytest
+
+from dashboard_compiler.dashboard_compiler import load
+
+# Find all YAML files in docs/examples (recursively)
+example_dir = Path('docs/examples')
+example_files = sorted(example_dir.rglob('*.yaml'))
+
+
+@pytest.mark.parametrize('example_path', example_files, ids=lambda p: str(p))
+def test_example_dashboard_compiles(example_path: Path) -> None:
+    """Test that each example dashboard compiles without errors.
+
+    Args:
+        example_path: Path to the example YAML file to compile.
+
+    """
+    dashboards = load(str(example_path))
+    assert len(dashboards) > 0, f'Should load at least one dashboard from {example_path}'


### PR DESCRIPTION
Fixes #395

This PR moves the 3 Aerospike dashboards from `inputs/` to `docs/examples/aerospike/` and fixes their schema issues to ensure they compile successfully.

## Changes

- Moved dashboards to `docs/examples/aerospike/`
- Fixed schema: changed `primary:` to `metrics:` in line charts
- Fixed panel overlaps by adjusting grid positions
- Added `test_example_dashboards.py` to test all examples compile
- Updated `docs/examples/index.md` with Aerospike section
- Removed examples from `.yamllint` ignore list

## Testing

All 322 tests passing, including new example compilation tests.

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-395-20251230-1547) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20600297793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Aerospike monitoring examples with pre-built dashboards for overview, node metrics, and namespace metrics.

* **Documentation**
  * Added Aerospike monitoring examples section to the documentation with usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->