### PR TITLE
feat: Add compact output for make ci, check, and fix commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ lint-markdown:
 # Check markdown without fixing
 lint-markdown-check:
 	@echo "Running markdownlint..."
-	@markdownlint -c .markdownlint.jsonc . --quiet
+	@markdownlint -c .markdownlint.jsonc . > /dev/null 2>&1 && echo "✓ Markdown checks passed" || (markdownlint -c .markdownlint.jsonc . && exit 1)
 
 # Auto-fix YAML issues
 lint-yaml:


### PR DESCRIPTION
Add --quiet flags to ruff check, ruff format, and markdownlint commands to reduce verbosity when checks pass. Override pytest verbosity with compact output flags. Make yamllint silent on success, verbose on failure. Silence npm install and compile output for extension tests.

This reduces output from ~400 lines to ~15 lines when all checks pass, while preserving full error details when checks fail.

Resolves #414

---

Generated with [Claude Code](https://claude.ai/code)