### PR TITLE
Add missing Poem for Datatables

### DIFF
--- a/docs/panels/datatable.md
+++ b/docs/panels/datatable.md
@@ -2,6 +2,39 @@
 
 The Datatable chart panel displays tabular data with customizable columns, sorting, pagination, and formatting options. Perfect for displaying detailed records and performing quick data analysis.
 
+## A Poem for the Spreadsheet Scholars
+
+_For those who know that sometimes you just need to see the rows:_
+
+```text
+When charts and graphs just won't suffice,
+And visual flair must pay the price,
+The datatable stands, precise and plain—
+Row after row, your data's domain.
+
+Sort ascending, descending too,
+Filter down to just a few.
+Columns wide or columns tight,
+Pagination keeps the load just right.
+
+Metrics summed at bottom's end,
+Summary rows, your data's friend.
+From service names to error codes,
+Each cell tells tales the table holds.
+
+Left-align text and right-align numbers,
+No visual tricks, no chart encumbers.
+Just pure data, clean and true—
+The datatable works hard for you.
+
+So here's to rows and columns straight,
+To tables that enumerate:
+Sometimes the simplest view prevails,
+When details matter, datatable never fails!
+```
+
+---
+
 ## Minimal Configuration Example
 
 ```yaml


### PR DESCRIPTION
The datatable.md panel documentation was missing a poem section that all other panel docs have. Added "A Poem for the Spreadsheet Scholars" to maintain consistency across all panel documentation files.