### PR TITLE
Remove vestigial data_view field from dashboard schema

### DIFF
--- a/docs/controls/config.md
+++ b/docs/controls/config.md
@@ -34,7 +34,6 @@ This example demonstrates multiple controls with custom widths and global contro
 dashboards:
   - name: "Application Monitoring Dashboard"
     description: "Dashboard with interactive controls."
-    data_view: "logs-*" # Default data view for panels
     settings:
       controls:
         label_position: "above"

--- a/docs/dashboard/dashboard.md
+++ b/docs/dashboard/dashboard.md
@@ -21,13 +21,12 @@ dashboards:
 
 ## Complex Configuration Example
 
-This example showcases a dashboard with various settings, a default data view, a global query, filters, controls, and multiple panels.
+This example showcases a dashboard with various settings, a global query, filters, controls, and multiple panels.
 
 ```yaml
 dashboards:
   - name: "Comprehensive Application Overview"
     description: "An overview of application performance and logs, with interactive filtering."
-    data_view: "production-logs-*" # Default data view for all items unless overridden
     settings:
       margins: true
       titles: true
@@ -86,7 +85,6 @@ The main object defining the dashboard.
 | `id` | `string` | An optional unique identifier for the dashboard. If not provided, one will be generated based on the name. | Generated ID | No |
 | `description` | `string` | A brief description of the dashboard's purpose or content. | `""` (empty string) | No |
 | `settings` | `DashboardSettings` object | Global settings for the dashboard. See [Dashboard Settings](#dashboard-settings-settings). | See defaults below | No |
-| `data_view` | `string` | The default data view (index pattern) ID or title used by items in this dashboard unless overridden. | `None` | No |
 | `query` | `Query` object | A global query (KQL or Lucene) applied to the dashboard. See [Queries Documentation](../queries/config.md). | `None` | No |
 | `filters` | `list of Filter objects` | A list of global filters applied to the dashboard. See [Filters Documentation](../filters/config.md). | `[]` (empty list) | No |
 | `controls` | `list of Control objects` | A list of control panels for the dashboard. See [Controls Documentation](../controls/config.md). | `[]` (empty list) | No |

--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -53,7 +53,6 @@ from dashboard_compiler.dashboard.config import Dashboard
 dashboard = Dashboard(
     name='Dashboard Name',  # Required: Display name
     description='Dashboard description',  # Optional: Description
-    data_view='logs-*',  # Optional: Default data view
 )
 ```
 

--- a/src/dashboard_compiler/dashboard/config.py
+++ b/src/dashboard_compiler/dashboard/config.py
@@ -49,9 +49,6 @@ class Dashboard(BaseCfgModel):
 
     settings: DashboardSettings = Field(default_factory=DashboardSettings)
 
-    data_view: str | None = Field(default=None)
-    """The default data view (index pattern) used by items in this dashboard."""
-
     query: LegacyQueryTypes | None = Field(default=None)
     """A query (KQL or Lucene) applied to the dashboard."""
 


### PR DESCRIPTION
The `data_view` field at the dashboard root level had no effect. The documentation incorrectly claimed it sets a default data view for items in the dashboard, but the field was never used during compilation or passed to panels/controls.

This removes the unused field and updates all documentation to reflect the actual behavior.

Fixes #447

🤖 Generated with [Claude Code](https://claude.ai/code)