### PR TITLE
feat: Add automatic build failure notification workflow

### DIFF
--- a/.github/workflows/notify-build-failure.yml
+++ b/.github/workflows/notify-build-failure.yml
@@ -27,7 +27,7 @@ jobs:
             The CI/CD pipeline failed on the main branch.
 
             **Workflow Run:** [{{workflow}} #{{runNumber}}]({{runUrl}})
-            **Commit:** {{sha}} by @{{sender}}
+            **Commit:** {{sha}} by `@{{sender}}`
             **Branch:** {{ref}}
             **Event:** {{eventName}}
             **Triggered:** {{date}}


### PR DESCRIPTION
## Summary

Implements automatic GitHub issue creation when builds fail on the main branch.

### Changes
- Added `github/notify-build-failure.yml` workflow configuration
- Uses `workflow_run` trigger to monitor the "Checks" workflow
- Leverages `jayqi/failed-build-issue-action@v1` for smart issue management
- Only triggers on main branch failures (excludes PRs)

### Deployment Required
⚠️ **Maintainer action needed:** Move `github/notify-build-failure.yml` to `.github/workflows/` to activate the workflow.

### Prerequisites
Before merging, enable "Read and write permissions" for workflows:
1. Settings → Actions → General
2. Workflow permissions → "Read and write permissions"

### How It Works
1. Monitors the "Checks" workflow via `workflow_run` trigger
2. On failure, searches for existing open issues labeled "build failed"
3. Comments on existing issue or creates new one with failure details
4. Includes workflow run link, commit info, and actionable checklist

Fixes #479

---
🤖 Generated with [Claude Code](https://claude.ai/code)