### PR TITLE
test: add e2e YAML tests for ES|QL XY charts

### DIFF
--- a/tests/panels/charts/xy/test_xy_e2e.py
+++ b/tests/panels/charts/xy/test_xy_e2e.py
@@ -9,7 +9,7 @@ from dashboard_compiler.dashboard_compiler import load, render
 from tests.conftest import de_json_kbn_dashboard
 
 
-async def test_esql_line_chart_e2e(tmp_path: Path) -> None:
+def test_esql_line_chart_e2e(tmp_path: Path) -> None:
     """Test ES|QL line chart end-to-end compilation from YAML.
 
     This test verifies the full compilation pipeline from YAML to Kibana dashboard JSON
@@ -88,7 +88,7 @@ dashboards:
     assert query_state['esql'] == 'FROM logs-* | STATS count() BY @timestamp'
 
 
-async def test_esql_bar_chart_e2e(tmp_path: Path) -> None:
+def test_esql_bar_chart_e2e(tmp_path: Path) -> None:
     """Test ES|QL bar chart end-to-end compilation from YAML with stacked mode and breakdown."""
     yaml_content = """---
 dashboards:
@@ -164,7 +164,7 @@ dashboards:
     assert query_state['esql'] == 'FROM metrics-* | STATS count() BY @timestamp, aerospike.namespace.name'
 
 
-async def test_esql_area_chart_e2e(tmp_path: Path) -> None:
+def test_esql_area_chart_e2e(tmp_path: Path) -> None:
     """Test ES|QL area chart end-to-end compilation from YAML with metrics and breakdown."""
     yaml_content = """---
 dashboards:


### PR DESCRIPTION
## Summary

Adds comprehensive end-to-end tests for ES|QL XY chart types (line, bar, area). These tests verify the full compilation pipeline from YAML to Kibana dashboard JSON.

## Changes

- Added test scenario for ES|QL line chart (exact YAML from issue #489)
- Added test scenario for ES|QL bar chart with stacked mode and breakdown
- Added test scenario for ES|QL area chart with metrics and breakdown
- Created dedicated e2e test file for ES|QL XY charts

## Testing

- All 3 ES|QL XY chart tests pass
- All CI checks pass (linting, typecheck, 507 total tests)

Closes #489

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering ES|QL XY chart visualizations (line, bar, area). Tests validate dashboard loading and rendering, chart metadata, panel structure (type and title), ES|QL queries, and visualization layer configuration (series types, accessors, x-axis, and color mappings) with snapshot checks to ensure stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->