### PR TITLE
fix: Combine panel type and title in preview layout

### DIFF
--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -520,9 +520,8 @@ export class PreviewPanel {
                 <div class="layout-panel" style="left: ${left}%; top: ${top}px; width: ${width}%; height: ${height}px;" title="${escapeHtml(panel.title)} (${typeLabel})">
                     <div class="panel-header">
                         <span class="panel-icon">${icon}</span>
-                        <span class="panel-type-label">${escapeHtml(typeLabel)}</span>
+                        <span class="panel-type-label">${escapeHtml(typeLabel)}: ${escapeHtml(panel.title || 'Untitled')}</span>
                     </div>
-                    <span class="panel-title">${escapeHtml(panel.title || 'Untitled')}</span>
                     <span class="panel-size">${panel.grid.w}x${panel.grid.h}</span>
                 </div>
             `;


### PR DESCRIPTION
## Summary

This PR addresses issue #560 by changing the extension preview panel format to display the type and title on a single line with a colon separator.

## Changes

- Modified `vscode-extension/src/previewPanel.ts` to combine the panel type label and title
- Removed the separate `panel-title` span element
- Added colon separator between type and title

## Before / After

**Before:**
```
# Metric
Number of Hosts
```

**After:**
```
# Metric: Number of Hosts
```

## Testing

- TypeScript compilation: ✅ Passed
- ESLint: ✅ Passed (no new issues)

Fixes #560

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard panel headers to display type label and title in a combined format (e.g., "TypeLabel: Panel Title"), streamlining the header structure while preserving all information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->