### PR TITLE
fix: handle boolean False values correctly in control compilation

### DIFF
--- a/src/dashboard_compiler/controls/compile.py
+++ b/src/dashboard_compiler/controls/compile.py
@@ -64,8 +64,8 @@ def compile_options_list_control(order: int, *, control: OptionsListControl) -> 
             dataViewId=control.data_view,
             fieldName=control.field,
             title=control.label,
-            runPastTimeout=control.wait_for_results or None,
-            singleSelect=control.singular or None,
+            runPastTimeout=return_if(var=control.wait_for_results, is_true=True, is_false=False, default=None),
+            singleSelect=return_if(var=control.singular, is_true=True, is_false=False, default=None),
             searchTechnique=match_technique_to_search_technique.get(control.match_technique, SearchTechnique.PREFIX),
             selectedOptions=[],
             sort=KbnControlSort(by='_count', direction='desc'),
@@ -150,7 +150,7 @@ def compile_esql_static_control(order: int, *, control: ESQLStaticValuesControl)
             controlType=EsqlControlType.STATIC_VALUES.value,
             title=control.title,
             selectedOptions=[],
-            singleSelect=control.single_select or None,
+            singleSelect=return_if(var=control.single_select, is_true=True, is_false=False, default=None),
             availableOptions=control.available_options,
         ),
     )
@@ -181,7 +181,7 @@ def compile_esql_query_control(order: int, *, control: ESQLQueryControl) -> KbnE
             controlType=EsqlControlType.VALUES_FROM_QUERY.value,
             title=control.title,
             selectedOptions=[],
-            singleSelect=control.single_select or None,
+            singleSelect=return_if(var=control.single_select, is_true=True, is_false=False, default=None),
             availableOptions=None,
         ),
     )

--- a/src/dashboard_compiler/controls/config.py
+++ b/src/dashboard_compiler/controls/config.py
@@ -84,13 +84,13 @@ class OptionsListControl(BaseControl):
     match_technique: MatchTechnique | None = Field(default=None, strict=False)  # strict=False for enum coercion
     """The search technique used for filtering options (e.g., 'prefix', 'contains', 'exact')."""
 
-    wait_for_results: bool = Field(default=False)
+    wait_for_results: bool | None = Field(default=None)
     """If set to true, delay the display of the list of values until the results are fully loaded."""
 
     preselected: list[str] = Field(default_factory=list)
     """A list of options that are preselected when the control is initialized."""
 
-    singular: bool = Field(default=False)
+    singular: bool | None = Field(default=None)
     """If true, the control allows only a single selection from the options list."""
 
     data_view: str = Field(...)
@@ -165,7 +165,7 @@ class ESQLStaticValuesControl(BaseControl):
     title: str = Field(...)
     """Display title for the control."""
 
-    single_select: bool = Field(default=False)
+    single_select: bool | None = Field(default=None)
     """If true, only allow single selection from the options."""
 
 
@@ -190,5 +190,5 @@ class ESQLQueryControl(BaseControl):
     title: str = Field(...)
     """Display title for the control."""
 
-    single_select: bool = Field(default=False)
+    single_select: bool | None = Field(default=None)
     """If true, only allow single selection from the options."""

--- a/tests/controls/test_controls.py
+++ b/tests/controls/test_controls.py
@@ -527,3 +527,126 @@ async def test_time_slider_control_validation_error() -> None:
             start_offset=0.8,
             end_offset=0.2,
         )
+
+
+async def test_options_list_with_multi_select() -> None:
+    """Test options list control with multi-select (singular: false)."""
+    config = {
+        'type': 'options',
+        'data_view': '27a3148b-d1d4-4455-8acf-e63c94071a5b',
+        'field': 'aerospike.namespace',
+        'label': 'Multi Select Test',
+        'singular': False,
+    }
+    result = compile_control_snapshot(config)
+    assert result == snapshot(
+        {
+            'grow': False,
+            'order': 0,
+            'width': 'medium',
+            'type': 'optionsListControl',
+            'explicitInput': {
+                'id': IsUUID,
+                'dataViewId': '27a3148b-d1d4-4455-8acf-e63c94071a5b',
+                'fieldName': 'aerospike.namespace',
+                'title': 'Multi Select Test',
+                'searchTechnique': 'prefix',
+                'selectedOptions': [],
+                'singleSelect': False,
+                'sort': {'by': '_count', 'direction': 'desc'},
+            },
+        }
+    )
+
+
+async def test_options_list_without_wait_for_results() -> None:
+    """Test options list control with wait_for_results: false."""
+    config = {
+        'type': 'options',
+        'data_view': '27a3148b-d1d4-4455-8acf-e63c94071a5b',
+        'field': 'aerospike.namespace',
+        'label': 'No Wait Test',
+        'wait_for_results': False,
+    }
+    result = compile_control_snapshot(config)
+    assert result == snapshot(
+        {
+            'grow': False,
+            'order': 0,
+            'width': 'medium',
+            'type': 'optionsListControl',
+            'explicitInput': {
+                'id': IsUUID,
+                'dataViewId': '27a3148b-d1d4-4455-8acf-e63c94071a5b',
+                'fieldName': 'aerospike.namespace',
+                'title': 'No Wait Test',
+                'searchTechnique': 'prefix',
+                'selectedOptions': [],
+                'runPastTimeout': False,
+                'sort': {'by': '_count', 'direction': 'desc'},
+            },
+        }
+    )
+
+
+async def test_esql_static_control_with_multi_select() -> None:
+    """Test ES|QL static control with multi-select (single_select: false)."""
+    config = {
+        'type': 'esql_static',
+        'variable_name': 'status',
+        'variable_type': 'values',
+        'available_options': ['200', '404', '500'],
+        'title': 'HTTP Status',
+        'single_select': False,
+    }
+    result = compile_control_snapshot(config)
+    assert result == snapshot(
+        {
+            'grow': False,
+            'order': 0,
+            'width': 'medium',
+            'type': 'esqlControl',
+            'explicitInput': {
+                'id': IsUUID,
+                'variableName': 'status',
+                'variableType': 'values',
+                'esqlQuery': '',
+                'controlType': 'STATIC_VALUES',
+                'title': 'HTTP Status',
+                'selectedOptions': [],
+                'singleSelect': False,
+                'availableOptions': ['200', '404', '500'],
+            },
+        }
+    )
+
+
+async def test_esql_query_control_with_multi_select() -> None:
+    """Test ES|QL query control with multi-select (single_select: false)."""
+    config = {
+        'type': 'esql_query',
+        'variable_name': 'host',
+        'variable_type': 'values',
+        'esql_query': 'FROM logs-* | STATS count BY host.name | KEEP host.name',
+        'title': 'Host Name',
+        'single_select': False,
+    }
+    result = compile_control_snapshot(config)
+    assert result == snapshot(
+        {
+            'grow': False,
+            'order': 0,
+            'width': 'medium',
+            'type': 'esqlControl',
+            'explicitInput': {
+                'id': IsUUID,
+                'variableName': 'host',
+                'variableType': 'values',
+                'esqlQuery': 'FROM logs-* | STATS count BY host.name | KEEP host.name',
+                'controlType': 'VALUES_FROM_QUERY',
+                'title': 'Host Name',
+                'selectedOptions': [],
+                'singleSelect': False,
+            },
+        }
+    )


### PR DESCRIPTION
Fixes #596

The bug was in `controls/compile.py` where `field or None` pattern was used for boolean fields. When a boolean field was explicitly set to `False`, the expression `False or None` would evaluate to `None`, causing the field to be omitted from the JSON output.

### Changes
1. Replace `field or None` with `return_if()` helper for all affected boolean fields
2. Update config model defaults from `bool = Field(default=False)` to `bool | None = Field(default=None)`
3. Add comprehensive test coverage for `False` boolean values

The fix allows multi-select ES|QL controls to work correctly by ensuring `single_select: false` is properly serialized as `"singleSelect": false` in the JSON output.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of unspecified states for control fields (single select, wait for results options) to correctly distinguish between explicitly disabled and unspecified configurations.

* **Tests**
  * Added test coverage for multi-select control scenarios and control flag validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->