### PR TITLE
feat: add --kibana-space-id option to support Kibana spaces

### DIFF
--- a/compiler/src/dashboard_compiler/cli.py
+++ b/compiler/src/dashboard_compiler/cli.py
@@ -234,6 +234,12 @@ def cli() -> None:
     ),
 )
 @click.option(
+    '--kibana-space-id',
+    type=str,
+    envvar='KIBANA_SPACE_ID',
+    help='Kibana space ID to upload dashboards to. If not specified, uses the default space. (env: KIBANA_SPACE_ID)',
+)
+@click.option(
     '--no-browser',
     is_flag=True,
     help='Prevent browser from opening automatically after successful upload.',
@@ -257,6 +263,7 @@ def compile_dashboards(  # noqa: PLR0913, PLR0912
     kibana_username: str | None,
     kibana_password: str | None,
     kibana_api_key: str | None,
+    kibana_space_id: str | None,
     no_browser: bool,
     overwrite: bool,
     kibana_no_ssl_verify: bool,
@@ -362,6 +369,7 @@ def compile_dashboards(  # noqa: PLR0913, PLR0912
                 kibana_username,
                 kibana_password,
                 kibana_api_key,
+                kibana_space_id,
                 overwrite,
                 not no_browser,
                 ssl_verify=not kibana_no_ssl_verify,
@@ -375,6 +383,7 @@ async def upload_to_kibana(  # noqa: PLR0913
     username: str | None,
     password: str | None,
     api_key: str | None,
+    space_id: str | None,
     overwrite: bool,
     open_browser: bool,
     ssl_verify: bool = True,
@@ -387,6 +396,7 @@ async def upload_to_kibana(  # noqa: PLR0913
         username: Basic auth username
         password: Basic auth password
         api_key: API key for authentication
+        space_id: Kibana space ID (optional)
         overwrite: Whether to overwrite existing objects
         open_browser: Whether to open browser after successful upload
         ssl_verify: Whether to verify SSL certificates (default: True)
@@ -400,6 +410,7 @@ async def upload_to_kibana(  # noqa: PLR0913
         username=username,
         password=password,
         api_key=api_key,
+        space_id=space_id,
         ssl_verify=ssl_verify,
     )
 
@@ -744,6 +755,12 @@ def extract_sample_data_command(  # noqa: PLR0913
     ),
 )
 @click.option(
+    '--kibana-space-id',
+    type=str,
+    envvar='KIBANA_SPACE_ID',
+    help='Kibana space ID where the dashboard is located. If not specified, uses the default space. (env: KIBANA_SPACE_ID)',
+)
+@click.option(
     '--kibana-no-ssl-verify',
     is_flag=True,
     help='Disable SSL certificate verification (useful for self-signed certificates in local development).',
@@ -761,6 +778,7 @@ def screenshot_dashboard(  # noqa: PLR0913
     kibana_username: str | None,
     kibana_password: str | None,
     kibana_api_key: str | None,
+    kibana_space_id: str | None,
     kibana_no_ssl_verify: bool,
 ) -> None:
     r"""Generate a PNG screenshot of a Kibana dashboard.
@@ -807,6 +825,7 @@ def screenshot_dashboard(  # noqa: PLR0913
             kibana_username=kibana_username,
             kibana_password=kibana_password,
             kibana_api_key=kibana_api_key,
+            kibana_space_id=kibana_space_id,
             ssl_verify=not kibana_no_ssl_verify,
         )
     )
@@ -825,6 +844,7 @@ async def generate_screenshot(  # noqa: PLR0913
     kibana_username: str | None,
     kibana_password: str | None,
     kibana_api_key: str | None,
+    kibana_space_id: str | None,
     ssl_verify: bool = True,
 ) -> None:
     """Generate a screenshot of a Kibana dashboard.
@@ -842,6 +862,7 @@ async def generate_screenshot(  # noqa: PLR0913
         kibana_username: Basic auth username
         kibana_password: Basic auth password
         kibana_api_key: API key for authentication
+        kibana_space_id: Kibana space ID (optional)
         ssl_verify: Whether to verify SSL certificates (default: True)
 
     Raises:
@@ -853,6 +874,7 @@ async def generate_screenshot(  # noqa: PLR0913
         username=kibana_username,
         password=kibana_password,
         api_key=kibana_api_key,
+        space_id=kibana_space_id,
         ssl_verify=ssl_verify,
     )
 
@@ -1092,6 +1114,12 @@ async def load_all_sample_data(  # noqa: PLR0913
     ),
 )
 @click.option(
+    '--kibana-space-id',
+    type=str,
+    envvar='KIBANA_SPACE_ID',
+    help='Kibana space ID where the dashboard is located. If not specified, uses the default space. (env: KIBANA_SPACE_ID)',
+)
+@click.option(
     '--no-browser',
     is_flag=True,
     help='Do not open browser automatically with pre-filled issue.',
@@ -1107,6 +1135,7 @@ def export_for_issue(  # noqa: PLR0913
     kibana_username: str | None,
     kibana_password: str | None,
     kibana_api_key: str | None,
+    kibana_space_id: str | None,
     no_browser: bool,
     kibana_no_ssl_verify: bool,
 ) -> None:
@@ -1143,6 +1172,7 @@ def export_for_issue(  # noqa: PLR0913
             kibana_username=kibana_username,
             kibana_password=kibana_password,
             kibana_api_key=kibana_api_key,
+            kibana_space_id=kibana_space_id,
             open_browser=not no_browser,
             ssl_verify=not kibana_no_ssl_verify,
         )
@@ -1155,6 +1185,7 @@ async def _export_dashboard_for_issue(  # noqa: PLR0913
     kibana_username: str | None,
     kibana_password: str | None,
     kibana_api_key: str | None,
+    kibana_space_id: str | None,
     open_browser: bool,
     ssl_verify: bool,
 ) -> None:
@@ -1166,6 +1197,7 @@ async def _export_dashboard_for_issue(  # noqa: PLR0913
         kibana_username: Basic auth username
         kibana_password: Basic auth password
         kibana_api_key: API key for authentication
+        kibana_space_id: Kibana space ID (optional)
         open_browser: Whether to open browser with pre-filled issue
         ssl_verify: Whether to verify SSL certificates
 
@@ -1178,6 +1210,7 @@ async def _export_dashboard_for_issue(  # noqa: PLR0913
         username=kibana_username,
         password=kibana_password,
         api_key=kibana_api_key,
+        space_id=kibana_space_id,
         ssl_verify=ssl_verify,
     )
 

--- a/compiler/tests/test_kibana_client.py
+++ b/compiler/tests/test_kibana_client.py
@@ -82,3 +82,48 @@ class TestKibanaClient:
         client = KibanaClient(url='http://localhost:5601')
         url = client.get_dashboard_url('my-dashboard-id')
         assert url == 'http://localhost:5601/app/dashboards#/view/my-dashboard-id'
+
+    def test_init_with_space_id(self) -> None:
+        """Test KibanaClient initialization with space ID."""
+        client = KibanaClient(
+            url='http://localhost:5601',
+            space_id='my-space',
+        )
+        assert client.url == 'http://localhost:5601'
+        assert client.space_id == 'my-space'
+
+    def test_get_api_url_without_space(self) -> None:
+        """Test API URL generation without space ID."""
+        client = KibanaClient(url='http://localhost:5601')
+        url = client._get_api_url('/api/saved_objects/_import')
+        assert url == 'http://localhost:5601/api/saved_objects/_import'
+
+    def test_get_api_url_with_space(self) -> None:
+        """Test API URL generation with space ID."""
+        client = KibanaClient(url='http://localhost:5601', space_id='my-space')
+        url = client._get_api_url('/api/saved_objects/_import')
+        assert url == 'http://localhost:5601/s/my-space/api/saved_objects/_import'
+
+    def test_get_api_url_with_space_reporting_api(self) -> None:
+        """Test API URL generation with space ID for reporting API."""
+        client = KibanaClient(url='http://localhost:5601', space_id='production')
+        url = client._get_api_url('/api/reporting/generate/pngV2')
+        assert url == 'http://localhost:5601/s/production/api/reporting/generate/pngV2'
+
+    def test_get_api_url_with_space_export_api(self) -> None:
+        """Test API URL generation with space ID for export API."""
+        client = KibanaClient(url='http://localhost:5601', space_id='staging')
+        url = client._get_api_url('/api/saved_objects/_export')
+        assert url == 'http://localhost:5601/s/staging/api/saved_objects/_export'
+
+    def test_get_dashboard_url_with_space(self) -> None:
+        """Test dashboard URL generation with space ID."""
+        client = KibanaClient(url='http://localhost:5601', space_id='my-space')
+        url = client.get_dashboard_url('my-dashboard-id')
+        assert url == 'http://localhost:5601/s/my-space/app/dashboards#/view/my-dashboard-id'
+
+    def test_get_api_url_non_api_path(self) -> None:
+        """Test API URL generation with non-API path (no space prefix added)."""
+        client = KibanaClient(url='http://localhost:5601', space_id='my-space')
+        url = client._get_api_url('/some/other/path')
+        assert url == 'http://localhost:5601/some/other/path'

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,6 +87,7 @@ The CLI supports configuration via environment variables:
 export KIBANA_URL=http://localhost:5601
 export KIBANA_USERNAME=elastic
 export KIBANA_PASSWORD=changeme
+export KIBANA_SPACE_ID=my-space  # Optional: target a specific Kibana space
 # OR use API key instead
 export KIBANA_API_KEY=your-api-key-here
 ```
@@ -109,6 +110,19 @@ kb-dashboard compile \
   --kibana-password changeme
 ```
 
+To upload to a specific Kibana space:
+
+```bash
+kb-dashboard compile --upload --kibana-space-id production
+```
+
+Or with environment variables:
+
+```bash
+export KIBANA_SPACE_ID=staging
+kb-dashboard compile --upload
+```
+
 ## Full Command Reference
 
 ### `kb-dashboard compile`
@@ -125,6 +139,7 @@ Compile YAML dashboard configurations to NDJSON format.
 - `--kibana-username USER` - Kibana username for basic auth (can use `KIBANA_USERNAME` env var)
 - `--kibana-password PASS` - Kibana password for basic auth (can use `KIBANA_PASSWORD` env var)
 - `--kibana-api-key KEY` - Kibana API key for authentication (can use `KIBANA_API_KEY` env var)
+- `--kibana-space-id TEXT` - Kibana space ID to upload dashboards to (can use `KIBANA_SPACE_ID` env var)
 - `--no-browser` - Do not open browser after upload
 - `--overwrite/--no-overwrite` - Overwrite existing dashboards in Kibana (default: `--overwrite`)
 - `--kibana-no-ssl-verify` - Disable SSL certificate verification
@@ -147,6 +162,7 @@ Generate a PNG screenshot of a Kibana dashboard.
 - `--kibana-username USER` - Kibana username
 - `--kibana-password PASS` - Kibana password
 - `--kibana-api-key KEY` - Kibana API key
+- `--kibana-space-id TEXT` - Kibana space ID where the dashboard is located
 - `--kibana-no-ssl-verify` - Disable SSL certificate verification
 
 ### `kb-dashboard export-for-issue`
@@ -160,6 +176,7 @@ Export a dashboard from Kibana and create a pre-filled GitHub issue for requesti
 - `--kibana-username USER` - Kibana username
 - `--kibana-password PASS` - Kibana password
 - `--kibana-api-key KEY` - Kibana API key
+- `--kibana-space-id TEXT` - Kibana space ID where the dashboard is located
 - `--no-browser` - Do not open browser automatically
 - `--kibana-no-ssl-verify` - Disable SSL certificate verification
 


### PR DESCRIPTION
## Summary

Adds support for targeting specific Kibana spaces via a new `--kibana-space-id` CLI option.

## Changes

- Added `space_id` parameter to `KibanaClient` class
- Implemented `_get_api_url()` helper to build space-aware URLs
- Added `--kibana-space-id` CLI option to `compile`, `screenshot`, and `export-for-issue` commands
- Updated all API endpoints to support `/s/{space_id}` prefix
- Added comprehensive test coverage (8 new tests)
- Updated CLI documentation with usage examples

## Testing

- All 669 tests pass
- Type checking passes
- Linting passes

Closes #629

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20792601626) | [Branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-629-20260107-1843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--kibana-space-id` CLI option and `KIBANA_SPACE_ID` environment variable to specify target Kibana space for compile, upload, screenshot, and export operations.

* **Documentation**
  * Updated documentation with examples for using the new space ID option across workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->