### PR TITLE
fix: Add missing griffe-pydantic configuration for field rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ plugins:
           options:
             show_source: false
             docstring_style: google
+            docstring_section_style: table
             show_root_heading: true
             show_root_full_path: false
             show_symbol_type_heading: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ classifiers = [
     "Topic :: Software Development :: Code Generators",
 ]
 
+dependencies = [
+    "dashboard-compiler",
+]
+
+[tool.uv.sources]
+dashboard-compiler = { path = "compiler", editable = true }
+
 [dependency-groups]
 docs = [
     "mkdocs>=1.6.0",


### PR DESCRIPTION
Both fixes are required together:
1. Add `docstring_section_style: table` to mkdocs.yml
   - Tells mkdocstrings to render Attributes sections as tables
2. Add dashboard-compiler as dependency in root pyproject.toml
   - Allows griffe-fieldz to dynamically import Pydantic models
   - Without this, griffe-fieldz fails silently and no fields are extracted

These fixes were originally added in commits efee3d5 and ccd066d but were
lost when PR #667 merged. Both fixes must be present together for pydantic
field rendering to work.

Verified: Built docs locally and confirmed fields render as tables with
proper Name, Type, and Description columns.

Fixes #686

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Docstring sections in generated documentation now render using table-style formatting for improved visual organization and clarity in API reference materials.

* **Chores**
  * Added dashboard-compiler as a project dependency with local editable source configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->