### PR TITLE
docs: Add direct YAML links to example dashboards

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -119,7 +119,7 @@ Comprehensive host monitoring dashboards for OpenTelemetry system metrics:
 - **[Host Details - Metadata](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/system_otel/04-host-details-metadata.yaml)** - Host resource attributes and metadata (ES|QL datatables)
 - **[Host Details - Logs](https://github.com/strawgate/kb-yaml-to-lens/blob/main/docs/examples/system_otel/05-host-details-logs.yaml)** - Host log messages (ES|QL datatable)
 
-**Use this when:** Monitoring infrastructure with OpenTelemetry hostmetricsreceiver.
+**Use this when:** Monitoring infrastructure with OpenTelemetry host metrics receiver.
 
 **Note:** Based on the [Elastic integrations repository](https://github.com/elastic/integrations/tree/main/packages/system_otel) dashboards. Some advanced panels (AI-powered features, legacy visualizations) are excluded as they're not yet supported by the compiler.
 


### PR DESCRIPTION
### Summary

Adds direct clickable links to individual YAML files for example dashboards that were missing them.

### Changes

- Add clickable links to individual YAML files for Aerospike examples (3 files)
- Add clickable links to individual YAML files for System OTel examples (5 files)
- Add clickable links to individual YAML files for Docker OTel examples (2 files)
- Update Docker OTel section header to use full GitHub URL for consistency

All links follow the existing pattern used by other examples in the documentation.

Fixes #688

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized dashboard examples into consolidated "Dashboards:" groups with concise descriptions
  * Replaced per-item headings with grouped sections and refined guidance wording (e.g., "Use this when")
  * Added explicit external links for Aerospike, OpenTelemetry (Hosts, Host Details, Logs) and Docker OpenTelemetry dashboards, including per-dashboard links
  * Reformatted content to be link-centric for easier access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->