### PR TITLE
feat: Auto-generate controls, filters, and queries config docs

### DIFF
--- a/docs/controls/config.md
+++ b/docs/controls/config.md
@@ -68,60 +68,44 @@ dashboards:
 
 Global settings for all controls on the dashboard. These are configured under the `settings.controls` path in your main dashboard YAML.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ------------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------- |
-| `label_position` | `Literal['inline', 'above']` | The position of the control label. | `inline` | No |
-| `apply_global_filters` | `boolean` | Whether to apply global filters to the control. | `true` | No |
-| `apply_global_timerange` | `boolean` | Whether to apply the global time range to the control. | `true` | No |
-| `ignore_zero_results` | `boolean` | Whether to ignore controls that return zero results. If `true`, controls with no results will be hidden. | `false` (controls with zero results are shown) | No |
-| `chain_controls` | `boolean` | Whether to chain controls together, allowing one control's selection to filter the options in the next. | `true` (hierarchical chaining) | No |
-| `click_to_apply` | `boolean` | Whether to require users to click an apply button before applying changes. | `false` (changes apply immediately) | No |
+::: dashboard_compiler.controls.config.ControlSettings
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Options List Control
 
 Allows users to select one or more values from a list to filter data.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ------------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `type` | `Literal['options']` | Specifies the control type. | `options` | Yes |
-| `id` | `string` | A unique identifier for the control. If not provided, one will be generated. | Generated UUID | No |
-| `width` | `Literal['small', 'medium', 'large']` | The width of the control in the dashboard layout. | `medium` | No |
-| `label` | `string` | The display label for the control. If not provided, a label may be inferred. | `None` | No |
-| `data_view` | `string` | The ID or title of the data view (index pattern) the control operates on. | N/A | Yes |
-| `field` | `string` | The name of the field within the data view that the control is associated with. | N/A | Yes |
-| `fill_width` | `boolean` | If true, the control will automatically adjust its width to fill available space. | `false` | No |
-| `match_technique` | `Literal['prefix', 'contains', 'exact']` | The search technique used for filtering options. See [Match Technique Enum](#match-technique-enum-match_technique). | `prefix` | No |
-| `wait_for_results` | `boolean` | If set to true, delay the display of the list of values until the results are fully loaded. | `false` | No |
-| `preselected` | `list of strings` | A list of options that are preselected when the control is initialized. | `[]` (empty list) | No |
-| `singular` | `boolean` | If true, the control allows only a single selection from the options list. | `false` | No |
+::: dashboard_compiler.controls.config.OptionsListControl
+    options:
+      show_root_heading: false
+      heading_level: 4
+
+#### Match Technique Options
+
+::: dashboard_compiler.controls.config.MatchTechnique
+    options:
+      show_root_heading: false
+      heading_level: 5
 
 ### Range Slider Control
 
 Allows users to select a range of numeric values to filter data.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `type` | `Literal['range']` | Specifies the control type. | `range` | Yes |
-| `id` | `string` | A unique identifier for the control. If not provided, one will be generated. | Generated UUID | No |
-| `width` | `Literal['small', 'medium', 'large']` | The width of the control in the dashboard layout. | `medium` | No |
-| `label` | `string` | The display label for the control. If not provided, a label may be inferred. | `None` | No |
-| `data_view` | `string` | The ID or title of the data view (index pattern) the control operates on. | N/A | Yes |
-| `field` | `string` | The name of the field within the data view that the control is associated with. | N/A | Yes |
-| `fill_width` | `boolean` | If true, the control will automatically adjust its width to fill available space. | `false` | No |
-| `step` | `integer` or `float` | The step value for the range, defining the granularity of selections. | `1` | No |
+::: dashboard_compiler.controls.config.RangeSliderControl
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Time Slider Control
 
 Allows users to select a sub-section of the dashboard's current time range. This control does not use a `data_view` or `field` as it operates on the global time context.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| -------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `type` | `Literal['time']` | Specifies the control type. | `time` | Yes |
-| `id` | `string` | A unique identifier for the control. If not provided, one will be generated. | Generated UUID | No |
-| `width` | `Literal['small', 'medium', 'large']` | The width of the control in the dashboard layout. | `medium` | No |
-| `label` | `string` | The display label for the control. If not provided, a label may be inferred. | `None` | No |
-| `start_offset` | `float` (between 0.0 and 1.0) | The start offset for the time range as a percentage of the global time range (e.g., `0.25` for 25%). Must be less than `end_offset`. | `0.0` (0%) | No |
-| `end_offset` | `float` (between 0.0 and 1.0) | The end offset for the time range as a percentage of the global time range (e.g., `0.75` for 75%). Must be greater than `start_offset`. | `1.0` (100%) | No |
+::: dashboard_compiler.controls.config.TimeSliderControl
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 **Note on Time Slider Offsets:** The YAML configuration expects `start_offset` and `end_offset` as float values between 0.0 (0%) and 1.0 (100%). Kibana internally represents these as percentages from 0.0 to 100.0. If not provided, Kibana defaults to `0.0` for start and `100.0` for end.
 
@@ -131,40 +115,36 @@ Allows users to filter ES|QL visualizations via variables. ES|QL controls can us
 
 **The control type is automatically determined based on the fields you provide:**
 
-- If you provide `choices`, it creates a static values control
+- If you provide `choices` with a single default value (or `multiple: false`), it creates a static single-select control
+- If you provide `choices` with a list default value (or `multiple: true`), it creates a static multi-select control
 - If you provide `query`, it creates a query-driven control
 
-#### Common Fields
+#### ES|QL Static Single-Select Control
 
-These fields apply to all ES|QL controls (both static and query-driven):
+For single-selection controls with predefined values.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| --- | --- | --- | --- | --- |
-| `type` | `Literal['esql']` | Specifies the control type. | `esql` | Yes |
-| `id` | `string` | A unique identifier for the control. If not provided, one will be generated. | Generated UUID | No |
-| `width` | `Literal['small', 'medium', 'large']` | The width of the control in the dashboard layout. | `medium` | No |
-| `label` | `string` | The display label for the control. | `None` | No |
-| `variable_name` | `string` | The name of the ESQL variable (e.g., `status_code`). Used in queries as `?variable_name`. | N/A | Yes |
-| `variable_type` | `string` | The type of variable. See [ESQL Variable Types](#esql-variable-types-variable_type). | `values` | No |
+::: dashboard_compiler.controls.config.ESQLStaticSingleSelectControl
+    options:
+      show_root_heading: false
+      heading_level: 5
 
-#### Static Values Control Fields
+#### ES|QL Static Multi-Select Control
 
-Additional fields for static values controls (when `choices` is provided):
+For multi-selection controls with predefined values.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| --- | --- | --- | --- | --- |
-| `choices` | `list of strings` | The static list of available values for this control. **Required for static values controls.** | N/A | Yes |
-| `default` | `string` or `list of strings` | Default selected value(s). If a string, auto-infers single-select mode. If a list, auto-infers multi-select mode. | `None` | No |
-| `multiple` | `boolean` | If true, allow multiple selection. If not set, auto-inferred from `default` type (string=false, list=true). | Inferred from `default` | No |
+::: dashboard_compiler.controls.config.ESQLStaticMultiSelectControl
+    options:
+      show_root_heading: false
+      heading_level: 5
 
-#### Query-Driven Control Fields
+#### ES|QL Query-Driven Control
 
-Additional fields for query-driven controls (when `query` is provided):
+For controls that dynamically fetch values from an ES|QL query.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| --- | --- | --- | --- | --- |
-| `query` | `string` | The ES\|QL query that returns the available values. **Required for query-driven controls.** | N/A | Yes |
-| `multiple` | `boolean` | If true, allow multiple selection from the options. | `false` | No |
+::: dashboard_compiler.controls.config.ESQLQueryControl
+    options:
+      show_root_heading: false
+      heading_level: 5
 
 #### Static Values Example
 
@@ -226,23 +206,12 @@ panels:
         - STATS total = COUNT(*)
 ```
 
-## ES|QL Variable Types (`variable_type`)
+## ES|QL Variable Types
 
-This defines the type of variable used in ES|QL controls. These match Kibana's `ESQLVariableType` enum.
-
-- `values`: (Default) Standard values variable type.
-- `multi_values`: Multi-value variable type.
-- `fields`: Fields variable type.
-- `time_literal`: Time literal variable type.
-- `functions`: Functions variable type.
-
-## Match Technique Enum (`match_technique`)
-
-This enum defines the possible search techniques used for filtering options in an `OptionsListControl`.
-
-- `prefix`: (Default) Filters options starting with the input text.
-- `contains`: Filters options containing the input text.
-- `exact`: Filters options matching the input text exactly.
+::: dashboard_compiler.controls.types.ESQLVariableType
+    options:
+      show_root_heading: false
+      heading_level: 3
 
 ## Related Documentation
 

--- a/docs/filters/config.md
+++ b/docs/filters/config.md
@@ -66,96 +66,77 @@ filters:
 
 ## Full Configuration Options
 
-All filter types can include the following base fields:
-
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | --------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `alias` | `string` | An optional alias for the filter, used for display purposes in Kibana. | `None` | No |
-| `disabled` | `boolean` | If `true`, the filter is defined but not applied. | `false` | No |
-
 ### Exists Filter
 
 Checks for the existence of a specific field.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | --------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `exists` | `string` | The field name to check for existence. | N/A | Yes |
-| `alias` | `string` | An optional alias for the filter. | `None` | No |
-| `disabled` | `boolean` | If `true`, the filter is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.ExistsFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Phrase Filter
 
 Matches documents where a specific field contains an exact phrase.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | --------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `field` | `string` | The field name to apply the filter to. | N/A | Yes |
-| `equals` | `string` | The exact phrase value that the field must match. | N/A | Yes |
-| `alias` | `string` | An optional alias for the filter. | `None` | No |
-| `disabled` | `boolean` | If `true`, the filter is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.PhraseFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Phrases Filter
 
 Matches documents where a specific field contains one or more of the specified phrases.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | ----------------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `field` | `string` | The field name to apply the filter to. | N/A | Yes |
-| `in` | `list of strings` | A list of phrases. Documents must match at least one of these phrases. | N/A | Yes |
-| `alias` | `string` | An optional alias for the filter. | `None` | No |
-| `disabled` | `boolean` | If `true`, the filter is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.PhrasesFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Range Filter
 
 Matches documents where a numeric or date field falls within a specified range. At least one of `gte`, `lte`, `gt`, or `lt` must be provided.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | --------- | -------------------------------------------------------------------------------- | -------------- | ----------------------- |
-| `field` | `string` | The field name to apply the filter to. | N/A | Yes |
-| `gte` | `string` | Greater than or equal to value. | `None` | No (but one must exist) |
-| `lte` | `string` | Less than or equal to value. | `None` | No (but one must exist) |
-| `gt` | `string` | Greater than value. | `None` | No (but one must exist) |
-| `lt` | `string` | Less than value. | `None` | No (but one must exist) |
-| `alias` | `string` | An optional alias for the filter. | `None` | No |
-| `disabled` | `boolean` | If `true`, the filter is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.RangeFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Custom Filter
 
 Allows for defining a custom Elasticsearch Query DSL filter.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | ---------------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `dsl` | `object (dict)` | The custom Elasticsearch query definition. | N/A | Yes |
-| `alias` | `string` | An optional alias for the filter. | `None` | No |
-| `disabled` | `boolean` | If `true`, the filter is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.CustomFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Negate Filter (`not`)
 
-Excludes documents that match the nested filter. This filter itself does not have `alias` or `disabled` directly; those would apply to the filter it contains or a parent filter.
+Excludes documents that match the nested filter.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| -------- | -------------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `not` | `FilterTypes` | The filter object to negate. Can be any of the other filter types or junctions. | N/A | Yes |
+::: dashboard_compiler.filters.config.NegateFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### And Filter (`and`)
 
 Matches documents that satisfy ALL of the specified nested filters.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | ----------------------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `and` | `list of FilterTypes` | A list of filter objects. All filters must match for a document to be included. | N/A | Yes |
-| `alias` | `string` | An optional alias for the AND group. | `None` | No |
-| `disabled` | `boolean` | If `true`, the entire AND group is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.AndFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ### Or Filter (`or`)
 
 Matches documents that satisfy AT LEAST ONE of the specified nested filters.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| ---------- | ----------------------- | -------------------------------------------------------------------------------- | -------------- | -------- |
-| `or` | `list of FilterTypes` | A list of filter objects. At least one filter must match. | N/A | Yes |
-| `alias` | `string` | An optional alias for the OR group. | `None` | No |
-| `disabled` | `boolean` | If `true`, the entire OR group is defined but not applied. | `false` | No |
+::: dashboard_compiler.filters.config.OrFilter
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 ## Related Documentation
 

--- a/docs/queries/config.md
+++ b/docs/queries/config.md
@@ -44,10 +44,10 @@ Queries are typically defined under a `query` key, either at the root of the `da
 
 Filters documents using the Kibana Query Language (KQL). This is often the default query language in Kibana.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| -------- | --------- | ------------------------------------------------ | -------------- | -------- |
-| `kql` | `string` | The KQL query string to apply. | N/A | Yes |
-| `query` | `object` | The parent object containing the `kql` key. | N/A | Yes |
+::: dashboard_compiler.queries.config.KqlQuery
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 **Usage Example (Dashboard Level):**
 
@@ -62,10 +62,10 @@ dashboards:
 
 Filters documents using the more expressive, but complex, Lucene query syntax.
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| -------- | --------- | ------------------------------------------------ | -------------- | -------- |
-| `lucene` | `string` | The Lucene query string to apply. | N/A | Yes |
-| `query` | `object` | The parent object containing the `lucene` key. | N/A | Yes |
+::: dashboard_compiler.queries.config.LuceneQuery
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 **Usage Example (Dashboard Level):**
 
@@ -78,11 +78,12 @@ dashboards:
 
 ### ESQL Query
 
-Uses Elasticsearch Query Language (ESQL) for data retrieval and aggregation. ESQL queries are typically used by specific panel types that are designed to work with ESQL's tabular results (e.g., ESQL-driven charts or tables). The configuration is a direct string under the `query` key for such panels.
+Uses Elasticsearch Query Language (ESQL) for data retrieval and aggregation. ESQL queries are typically used by specific panel types that are designed to work with ESQL's tabular results (e.g., ESQL-driven charts or tables).
 
-| YAML Key | Data Type | Description | Kibana Default | Required |
-| -------- | --------- | --------------------------------------------------------------------------- | -------------- | -------- |
-| `query` | `string` or `list[string]` | The ESQL query string, or an array of query parts to concatenate. Array parts are joined with the pipe operator (`\|`). Nested arrays (from YAML anchor expansion) are automatically flattened. | N/A | Yes |
+::: dashboard_compiler.queries.config.ESQLQuery
+    options:
+      show_root_heading: false
+      heading_level: 4
 
 **Usage Example (Panel Level - String Format):**
 


### PR DESCRIPTION
## Summary

Replace manual configuration tables with auto-generated documentation from Pydantic models for controls, filters, and queries. This eliminates duplication and ensures docs stay in sync with code.

## Changes

- Convert 7 control type tables to mkdocstrings directives
- Convert 8 filter type tables to mkdocstrings directives
- Convert 3 query type tables to mkdocstrings directives
- Document MatchTechnique enum inline using mkdocstrings
- Document ESQLVariableType enum inline using mkdocstrings

## Benefits

- ✅ Single source of truth in config.py files
- ✅ Docs auto-update when fields change
- ✅ Type information automatically included
- ✅ Eliminates manual table maintenance burden

## Scope

- 18 configuration tables replaced with auto-generated content
- 2 enums documented inline using mkdocstrings
- No new hooks created (as requested)
- Net change: -49 lines, much more maintainable

Related to #614

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured configuration documentation for controls, filters, and queries with improved organization and clearer modular layout for enhanced readability and ease of reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->