### PR TITLE
fix: Update ES|QL snippets to match current schema

### DIFF
--- a/vscode-extension/snippets/dashboards.json
+++ b/vscode-extension/snippets/dashboards.json
@@ -520,7 +520,7 @@
       "    query: |",
       "      FROM ${10:logs-*}",
       "      | STATS ${11:metric_value} = ${12|COUNT(*),AVG(field),SUM(field)|} BY ${13:time_bucket} = BUCKET(@timestamp, 1 hour)",
-      "      ${14:| ORDER ${13:time_bucket} ASC}",
+      "      ${14:| SORT ${13:time_bucket} ASC}",
       "    metrics:",
       "      - field: ${11:metric_value}",
       "        ${15:id: ${16:metric_1}}",


### PR DESCRIPTION
Fixed 5 ES|QL snippets that had schema validation errors:

1. **Fixed query structure (4 snippets)** - Changed nested `query: { esql: | ... }` to flat `query: |` to match the current panel discriminator pattern
2. **Added missing required fields (3 snippets)**:
   - ESQL Metric Panel: Added `primary` field
   - ESQL Line Chart: Added `metrics` field
   - ESQL Bar Chart: Added `metrics` field
3. **Removed invalid fields (1 snippet)**:
   - ESQL XY Chart: Removed unsupported `dimensions` and `appearance.series` fields

These snippets became outdated after the December 2025 panel discriminator refactoring (commit ab45b24).

Resolves #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)) • [Branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-702-20260108-1916) • [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20828785379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured ES|QL queries in dashboard snippets to a flatter, inline query format for consistency.
  * Introduced explicit metric fields (exposed primary metric_value) across metric, line, bar, and datatable panels.
  * Removed time_bucket dimension from relevant panels and aligned appearance, sorting, limiting, and legend defaults accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->