### PR TITLE
fix: standardize ES|QL time_field to snake_case

### DIFF
--- a/compiler/src/dashboard_compiler/panels/charts/config.py
+++ b/compiler/src/dashboard_compiler/panels/charts/config.py
@@ -116,7 +116,7 @@ class ESQLPanelFieldsMixin(BaseCfgModel):
     query: 'ESQLQueryTypes' = Field(...)
     """The ES|QL query to execute."""
 
-    time_field: str = Field(default='@timestamp', alias='timeField')
+    time_field: str = Field(default='@timestamp')
     """The time field to use for the dashboard time picker. Defaults to '@timestamp'."""
 
 

--- a/compiler/tests/panels/charts/test_compile_charts.py
+++ b/compiler/tests/panels/charts/test_compile_charts.py
@@ -428,7 +428,7 @@ class TestCompileESQLChartState:
                 'esql': {
                     'type': 'metric',
                     'query': 'FROM logs-* | STATS count()',
-                    'timeField': 'event.created',
+                    'time_field': 'event.created',
                     'primary': {'field': 'count(*)', 'id': 'metric1'},
                 },
             }
@@ -455,7 +455,7 @@ class TestCompileESQLChartState:
                 'esql': {
                     'type': 'pie',
                     'query': 'FROM logs-* | STATS count() BY status',
-                    'timeField': 'timestamp',
+                    'time_field': 'timestamp',
                     'slice_by': [{'field': 'status', 'id': 'group1'}],
                     'metrics': [{'field': 'count(*)', 'id': 'metric1'}],
                 },
@@ -483,7 +483,7 @@ class TestCompileESQLChartState:
                 'esql': {
                     'type': 'bar',
                     'query': 'FROM metrics-* | STATS count() BY @timestamp',
-                    'timeField': 'event.timestamp',
+                    'time_field': 'event.timestamp',
                     'dimension': {'field': '@timestamp', 'id': 'dim1'},
                     'metrics': [{'field': 'count(*)', 'id': 'metric1'}],
                 },


### PR DESCRIPTION
## Summary

Removes the camelCase `timeField` alias and standardizes on snake_case `time_field` for ES|QL panels.

## Changes

- Removed `alias='timeField'` from `ESQLPanelFieldsMixin.time_field` in config.py
- Updated 3 test cases to use `time_field` instead of `timeField`

## Impact

Breaking change: YAML files using `timeField` must be updated to `time_field`. However, no existing YAML files in the repository use this field, so the impact is zero.

Closes #703

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated ES|QL panel time field configuration. The default time field behavior remains unchanged, but internal field naming conventions have been standardized to improve consistency across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->