### PR TITLE
fix: Resolve docs build failures with broken anchor links

### DIFF
--- a/docs/api/controls.md
+++ b/docs/api/controls.md
@@ -31,3 +31,4 @@ Control configuration and compilation.
 ::: dashboard_compiler.controls.config.TimeSliderControl
     options:
       show_source: true
+      members: false

--- a/docs/api/filters.md
+++ b/docs/api/filters.md
@@ -37,6 +37,7 @@ Filter configuration and compilation.
 ::: dashboard_compiler.filters.config.RangeFilter
     options:
       show_source: true
+      members: false
 
 ## Negate Filter
 

--- a/docs/panels/base.md
+++ b/docs/panels/base.md
@@ -69,7 +69,7 @@ These fields are available for all panel types and are inherited from the `BaseP
 | `description` | `string` | A brief description of the panel's content or purpose. This is often shown on hover or in panel information. | `""` (empty string, if `None`) | No |
 | `size` | `Size` object | **Recommended:** Defines the panel's width and height. See [Size Object Configuration](#size-object-configuration-size) below. | `w: 12, h: 8` | No* |
 | `position` | `Position` object | **Optional:** Defines the panel's x/y coordinates. Omit for automatic positioning. See [Position Object Configuration](#position-object-configuration-position) below. | Auto-calculated | No |
-| `grid` | `Grid` object | **Legacy:** Combined position and size. See [Grid Object Configuration](#grid-object-configuration-grid---legacy) below. Use `size` + `position` instead. | N/A | No* |
+| `grid` | `Grid` object | **Legacy:** Combined position and size. See [Grid Object Configuration](#grid-object-configuration-legacy) below. Use `size` + `position` instead. | N/A | No* |
 
 \* Either `grid` OR (`size` + optional `position`) must be provided. The `size` + `position` approach is recommended for new dashboards.
 
@@ -143,7 +143,7 @@ size:
   h: 8
 ```
 
-### Grid Object Configuration (`grid`) - Legacy
+### Grid Object Configuration (Legacy)
 
 **Note:** The `grid` field is supported for backward compatibility, but the `size` + `position` approach is recommended for new dashboards.
 

--- a/docs/panels/esql.md
+++ b/docs/panels/esql.md
@@ -88,7 +88,7 @@ This is the main object for an ESQL-based visualization. It inherits from the [B
 | `title` | `string` | The title displayed on the panel header. Inherited from BasePanel. | `""` (empty string) | No |
 | `hide_title` | `boolean` | If `true`, the panel title will be hidden. Inherited from BasePanel. | `false` | No |
 | `description` | `string` | A brief description of the panel. Inherited from BasePanel. | `""` (empty string, if `None`) | No |
-| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](base.md#grid-object-configuration-grid). | N/A | Yes |
+| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](base.md#grid-object-configuration-legacy). | N/A | Yes |
 | `esql` | `string` or `ESQLQuery` object | The ESQL query string. See [Queries Documentation](../queries/config.md#esql-query). | N/A | Yes |
 | `chart` | `ESQLChartTypes` object | Defines the actual ESQL visualization configuration. This can be [ESQL Metric Chart](#esql-metric-chart-charttype-metric), [ESQL Pie Chart](#esql-pie-chart-charttype-pie), [ESQL Bar Chart](#esql-bar-chart-charttype-bar), [ESQL Line Chart](#esql-line-chart-charttype-line), or [ESQL Area Chart](#esql-area-chart-charttype-area). | N/A | Yes |
 

--- a/docs/panels/lens.md
+++ b/docs/panels/lens.md
@@ -87,12 +87,12 @@ This is the main object for a Lens-based visualization. It inherits from the [Ba
 | `title` | `string` | The title displayed on the panel header. Inherited from BasePanel. | `""` (empty string) | No |
 | `hide_title` | `boolean` | If `true`, the panel title will be hidden. Inherited from BasePanel. | `false` | No |
 | `description` | `string` | A brief description of the panel. Inherited from BasePanel. | `""` (empty string, if `None`) | No |
-| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](base.md#grid-object-configuration-grid). | N/A | Yes |
+| `grid` | `Grid` object | Defines the panel's position and size. Inherited from BasePanel. See [Grid Object Configuration](base.md#grid-object-configuration-legacy). | N/A | Yes |
 | `query` | `LegacyQueryTypes` object (KQL or Lucene) | A panel-specific query to filter data for this Lens visualization. See [Queries Documentation](../queries/config.md). | `None` (uses dashboard query) | No |
 | `filters` | `list of FilterTypes` | A list of panel-specific filters. See [Filters Documentation](../filters/config.md). | `[]` (empty list) | No |
 | `chart` | `LensChartTypes` object | Defines the actual Lens visualization configuration. This will be one of [Lens Metric Chart](#lens-metric-chart-charttype-metric) or [Lens Pie Chart](#lens-pie-chart-charttype-pie). | N/A | Yes |
 
-**Note**: For XY charts (line, bar, area), a `layers` field is available to add reference lines and additional data layers. See the [XY Chart Panel Configuration](xy.md#reference-lines-multi-layer-panels) documentation for details.
+**Note**: For XY charts (line, bar, area), a `layers` field is available to add reference lines and additional data layers. See the [XY Chart Panel Configuration](xy.md#reference-lines) documentation for details.
 
 ---
 


### PR DESCRIPTION
Fixes #706

## Summary

Resolved all mkdocs strict mode failures caused by broken anchor links and duplicate primary URLs.

## Changes

1. **Fixed broken anchor links:**
   - Updated heading format from "Grid Object Configuration (`grid`) - Legacy" to "Grid Object Configuration (Legacy)"
   - Updated all references to use correct anchor #grid-object-configuration-legacy
   - Fixed lens.md reference to xy.md from #reference-lines-multi-layer-panels to #reference-lines

2. **Fixed duplicate primary URLs:**
   - Added `members: false` to TimeSliderControl in API reference
   - Added `members: false` to RangeFilter in API reference
   - Prevents duplicate member anchors while keeping classes in both locations

## Testing

- ✓ `mkdocs build --strict` passes without warnings
- ✓ All internal documentation links resolve correctly

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated configuration documentation for Time Slider Control and Range Filter
  * Corrected Grid Object Configuration references and improved documentation link accuracy across panel documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->