### PR TITLE
fix: Support multiple metrics in ES|QL XY charts

### DIFF
--- a/compiler/src/dashboard_compiler/panels/charts/xy/compile.py
+++ b/compiler/src/dashboard_compiler/panels/charts/xy/compile.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from dashboard_compiler.panels.charts.base.compile import compile_color_mapping
 from dashboard_compiler.panels.charts.base.config import LegendVisibleEnum
-from dashboard_compiler.panels.charts.esql.columns.compile import compile_esql_dimensions, compile_esql_metric
+from dashboard_compiler.panels.charts.esql.columns.compile import compile_esql_dimensions, compile_esql_metrics
 from dashboard_compiler.panels.charts.esql.columns.view import KbnESQLColumnTypes
 from dashboard_compiler.panels.charts.lens.columns.view import (
     KbnLensColumnTypes,
@@ -547,7 +547,7 @@ def compile_esql_xy_chart(
     """
     layer_id = get_layer_id(esql_xy_chart)
 
-    metrics = [compile_esql_metric(esql_xy_chart.metrics[0])]  # For now just handle first metric
+    metrics = compile_esql_metrics(esql_xy_chart.metrics)
     metric_ids = [metric.columnId for metric in metrics]
 
     dimensions = []


### PR DESCRIPTION
## Summary

ES|QL XY charts (line, bar, area) were hardcoded to only compile the first metric, causing compilation failures with cryptic error messages when users provided multiple metrics. This PR fixes the implementation to compile all metrics.

## Changes

- Updated `compile_esql_xy_chart()` to use `compile_esql_metrics()` for all metrics
- Updated imports to use `compile_esql_metrics` (removed unused `compile_esql_metric`)
- Added `test_esql_line_chart_two_metrics_e2e()` to verify multi-metric support

## Test Plan

- [x] Added new test case for two metrics
- [x] All existing tests pass
- [x] `make check` passes (lint + typecheck + unit tests)

Fixes #710

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-710-20260108-2202) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20833251044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* XY and line charts now fully support multiple metrics per visualization, enabling comprehensive side-by-side metric comparisons on a single chart

## Tests
* Introduced comprehensive end-to-end test scenarios for multi-metric line charts, validating query compilation and visualization rendering accuracy

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->