### PR TITLE
Add YAML dashboard for aws_vpcflow_otel integration

### DIFF
--- a/docs/examples/aws_vpcflow_otel/README.md
+++ b/docs/examples/aws_vpcflow_otel/README.md
@@ -1,6 +1,6 @@
-# AWS VPC Flow Logs OTEL Dashboard
+# AWS VPC Flow Logs OTEL Dashboards
 
-DevOps/SRE monitoring dashboard for AWS VPC Flow Logs collected via OpenTelemetry.
+DevOps/SRE monitoring dashboards for AWS VPC Flow Logs collected via OpenTelemetry.
 
 ## Usage
 
@@ -23,59 +23,61 @@ kb-dashboard compile --input-dir docs/examples/aws_vpcflow_otel --output-dir out
   - `source.address`, `source.port`, `destination.address`, `destination.port`
   - `network.protocol.name`, `network.interface.name`, `cloud.account.id`
 
-## Dashboard Controls (7)
+## Dashboards
 
-| Control | Field | Purpose |
-|---------|-------|---------|
-| Cloud Account ID | `cloud.account.id` | Filter by AWS account |
-| Network Interface | `network.interface.name` | Filter by ENI |
-| Action | `aws.vpc.flow.action` | Filter ACCEPT/REJECT |
-| Source IP | `source.address` | Filter by source IP |
-| Destination IP | `destination.address` | Filter by destination IP |
-| Source Port | `source.port` | Filter by source port |
-| Destination Port | `destination.port` | Filter by destination port |
+This example includes 3 dashboards:
 
-## Panels (22 total)
+### 1. VPC Flow Logs Overview
 
-### KPI Metrics (5 metrics + 1 header)
-- **Total Flow Records** - Count of all flow logs
-- **Rejection Rate** - Percentage of rejected flows
-- **Total Bandwidth** - Sum of bytes transferred
-- **Active Interfaces** - Count of unique ENIs
-- **Cloud Accounts** - Count of unique AWS accounts
+High-level KPIs and time-series trends for quick status assessment.
 
-### Traffic Distribution (3 charts + 1 header)
-- **Top Protocols** - Pie chart by protocol
-- **Top Interfaces by Traffic** - Bar chart by bytes
-- **Top Destination Ports** - Bar chart by flow count
+**Controls (3):** Cloud Account ID, Network Interface, Action
 
-### Time-Series Trends (2 charts + 1 header)
-- **Traffic Volume Over Time** - Stacked area chart (ACCEPT/REJECT) with color coding
-- **Bandwidth Usage Over Time** - Line chart of bytes
+**Panels (8):**
 
-### Volume Change Detection (1 table + 1 header)
-- **Significant Volume Changes by Interface** - Compares baseline period vs current period to detect traffic anomalies
+- KPI Metrics (5 metrics + 1 header)
+  - Total Flow Records, Rejection Rate, Total Bandwidth, Active Interfaces, Cloud Accounts
+- Time-Series Trends (2 charts + 1 header)
+  - Traffic Volume Over Time (stacked area - ACCEPT/REJECT)
+  - Bandwidth Usage Over Time (line chart)
 
-### Source Analysis (1 table + 1 header)
-- **Top Source IPs** - Datatable with flows, bytes, rejection rate
+### 2. Traffic Analysis
 
-### Security Deep Dive (3 panels + 1 header)
-- **Rejected Traffic by Protocol** - Bar chart (red color)
-- **Top Rejected Ports** - Bar chart (red color)
-- **Detailed Rejection Logs** - Datatable with full log details
+Detailed traffic distribution, source analysis, and security deep dive.
 
-### Interface Analysis (1 chart + 1 header)
-- **Interface Traffic Analysis** - Stacked bar by interface with ACCEPT (green) / REJECT (red) breakdown
+**Controls (7):** Cloud Account ID, Network Interface, Action, Source IP, Destination IP, Source Port, Destination Port
 
-### Account Analysis (1 table + 1 header)
-- **Traffic by Cloud Account** - Multi-account metrics datatable
+**Panels (12):**
+
+- Traffic Distribution (3 charts + 1 header)
+  - Top Protocols (pie), Top Interfaces by Traffic (bar), Top Destination Ports (bar)
+- Volume Change Detection (1 table + 1 header)
+  - Significant Volume Changes by Interface
+- Source Analysis (1 table + 1 header)
+  - Top Source IPs - Detailed
+- Security Deep Dive (3 panels + 1 header)
+  - Rejected Traffic by Protocol (bar), Top Rejected Ports (bar), Detailed Rejection Logs (table)
+
+### 3. Interface Analysis
+
+Per-interface and per-account metrics for infrastructure analysis.
+
+**Controls (3):** Cloud Account ID, Network Interface, Action
+
+**Panels (4):**
+
+- Interface Analysis (1 chart + 1 header)
+  - Interface Traffic Analysis (stacked bar - ACCEPT/REJECT)
+- Account Analysis (1 table + 1 header)
+  - Traffic by Cloud Account
 
 ## Features
 
 - **Color coding**: REJECT traffic is shown in red (#BD271E), ACCEPT in green (#00BF6F)
-- **Section headers**: Thin markdown panels organize the dashboard into logical sections
+- **Section headers**: Markdown panels organize each dashboard into logical sections
 - **Compact metrics**: KPI metrics use `hide_title: true` for a cleaner look
-- **Volume change detection**: Compares a 30-minute baseline window (10-40 min after time picker start) with current window (40-10 min before time picker end)
+- **Auto-layout**: Panels use only `size` - positions are calculated automatically
+- **Volume change detection**: Compares a 30-minute baseline window with current window
 
 ## Source
 

--- a/docs/examples/aws_vpcflow_otel/dashboards.yaml
+++ b/docs/examples/aws_vpcflow_otel/dashboards.yaml
@@ -1,6 +1,155 @@
 ---
 dashboards:
+  # Dashboard 1: Overview - High-level KPIs and trends
   - name: '[AWS VPC OTEL] VPC Flow Logs Overview'
+    filters:
+      - field: data_stream.dataset
+        equals: aws.vpcflow.otel
+    controls:
+      - type: options
+        label: Cloud Account ID
+        width: medium
+        data_view: logs-*
+        field: cloud.account.id
+      - type: options
+        label: Network Interface
+        width: medium
+        data_view: logs-*
+        field: network.interface.name
+      - type: options
+        label: Action
+        width: small
+        data_view: logs-*
+        field: aws.vpc.flow.action
+    panels:
+      # KPI Metrics
+      - markdown:
+          content: '### KPI Metrics'
+        size: {w: 48, h: 2}
+      - title: Total Flow Records
+        hide_title: true
+        size: {w: 10, h: 4}
+        esql:
+          type: metric
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel"
+            - STATS total_flows = COUNT()
+          primary:
+            field: total_flows
+            label: Flow Records
+      - title: Rejection Rate
+        hide_title: true
+        size: {w: 10, h: 4}
+        esql:
+          type: metric
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel"
+            - STATS total_flows = COUNT(), rejected_flows = COUNT(*) WHERE aws.vpc.flow.action == "REJECT"
+            - EVAL rejection_rate = rejected_flows / total_flows
+          primary:
+            field: rejection_rate
+            label: Rejection Rate
+            format:
+              type: percent
+              decimals: 1
+      - title: Total Bandwidth
+        hide_title: true
+        size: {w: 10, h: 4}
+        esql:
+          type: metric
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND aws.vpc.flow.bytes IS NOT NULL
+            - STATS total_bytes = SUM(aws.vpc.flow.bytes)
+          primary:
+            field: total_bytes
+            label: Total Bandwidth
+            format:
+              type: bytes
+      - title: Active Interfaces
+        hide_title: true
+        size: {w: 9, h: 4}
+        esql:
+          type: metric
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND network.interface.name IS NOT NULL
+            - STATS unique_interfaces = COUNT_DISTINCT(network.interface.name)
+          primary:
+            field: unique_interfaces
+            label: Active Interfaces
+      - title: Cloud Accounts
+        hide_title: true
+        size: {w: 9, h: 4}
+        esql:
+          type: metric
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND cloud.account.id IS NOT NULL
+            - STATS unique_accounts = COUNT_DISTINCT(cloud.account.id)
+          primary:
+            field: unique_accounts
+            label: Cloud Accounts
+
+      # Time-Series Trends
+      - markdown:
+          content: '### Time-Series Trends'
+        size: {w: 48, h: 2}
+      - title: Traffic Volume Over Time
+        size: {w: 48, h: 12}
+        esql:
+          type: area
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND aws.vpc.flow.action IS NOT NULL
+            - STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)
+            - SORT time_bucket ASC
+          mode: stacked
+          dimension:
+            field: time_bucket
+          metrics:
+            - field: flow_count
+              label: Flow Count
+          breakdown:
+            field: aws.vpc.flow.action
+          color:
+            palette: eui_amsterdam_color_blind
+            assignments:
+              - value: REJECT
+                color: '#BD271E'
+              - value: ACCEPT
+                color: '#00BF6F'
+          appearance:
+            x_axis:
+              title: '@timestamp'
+            y_left_axis:
+              title: Flow Count
+      - title: Bandwidth Usage Over Time
+        size: {w: 48, h: 12}
+        esql:
+          type: line
+          query:
+            - FROM logs-*
+            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND aws.vpc.flow.bytes IS NOT NULL
+            - STATS total_bytes = SUM(aws.vpc.flow.bytes) BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)
+            - SORT time_bucket ASC
+          dimension:
+            field: time_bucket
+          metrics:
+            - field: total_bytes
+              label: Bytes
+              format:
+                type: bytes
+          appearance:
+            x_axis:
+              title: '@timestamp'
+            y_left_axis:
+              title: Bandwidth
+
+  # Dashboard 2: Traffic Analysis - Distribution, sources, and security
+  - name: '[AWS VPC OTEL] Traffic Analysis'
     filters:
       - field: data_stream.dataset
         equals: aws.vpcflow.otel
@@ -41,91 +190,12 @@ dashboards:
         data_view: logs-*
         field: destination.port
     panels:
-      # Section 1: KPI Metrics (y:0-5)
-      - markdown:
-          content: '### KPI Metrics'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 0}
-      - title: Total Flow Records
-        hide_title: true
-        size: {w: 10, h: 4}
-        position: {x: 0, y: 1}
-        esql:
-          type: metric
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel"
-            - STATS total_flows = COUNT()
-          primary:
-            field: total_flows
-            label: Flow Records
-      - title: Rejection Rate
-        hide_title: true
-        size: {w: 10, h: 4}
-        position: {x: 10, y: 1}
-        esql:
-          type: metric
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel"
-            - STATS total_flows = COUNT(), rejected_flows = COUNT(*) WHERE aws.vpc.flow.action == "REJECT"
-            - EVAL rejection_rate = rejected_flows / total_flows
-          primary:
-            field: rejection_rate
-            label: Rejection Rate
-            format:
-              type: percent
-              decimals: 1
-      - title: Total Bandwidth
-        hide_title: true
-        size: {w: 10, h: 4}
-        position: {x: 20, y: 1}
-        esql:
-          type: metric
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND aws.vpc.flow.bytes IS NOT NULL
-            - STATS total_bytes = SUM(aws.vpc.flow.bytes)
-          primary:
-            field: total_bytes
-            label: Total Bandwidth
-            format:
-              type: bytes
-      - title: Active Interfaces
-        hide_title: true
-        size: {w: 9, h: 4}
-        position: {x: 30, y: 1}
-        esql:
-          type: metric
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND network.interface.name IS NOT NULL
-            - STATS unique_interfaces = COUNT_DISTINCT(network.interface.name)
-          primary:
-            field: unique_interfaces
-            label: Active Interfaces
-      - title: Cloud Accounts
-        hide_title: true
-        size: {w: 9, h: 4}
-        position: {x: 39, y: 1}
-        esql:
-          type: metric
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND cloud.account.id IS NOT NULL
-            - STATS unique_accounts = COUNT_DISTINCT(cloud.account.id)
-          primary:
-            field: unique_accounts
-            label: Cloud Accounts
-
-      # Section 2: Traffic Distribution (y:5-18)
+      # Traffic Distribution
       - markdown:
           content: '### Traffic Distribution'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 5}
+        size: {w: 48, h: 2}
       - title: Top Protocols
         size: {w: 16, h: 12}
-        position: {x: 0, y: 6}
         esql:
           type: pie
           query:
@@ -141,7 +211,6 @@ dashboards:
             - field: network.protocol.name
       - title: Top Interfaces by Traffic
         size: {w: 16, h: 12}
-        position: {x: 16, y: 6}
         esql:
           type: bar
           query:
@@ -164,7 +233,6 @@ dashboards:
               title: Bytes
       - title: Top Destination Ports
         size: {w: 16, h: 12}
-        position: {x: 32, y: 6}
         esql:
           type: bar
           query:
@@ -184,72 +252,12 @@ dashboards:
             y_left_axis:
               title: Flow Count
 
-      # Section 3: Time-Series Trends (y:18-44)
-      - markdown:
-          content: '### Time-Series Trends'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 18}
-      - title: Traffic Volume Over Time
-        size: {w: 48, h: 12}
-        position: {x: 0, y: 19}
-        esql:
-          type: area
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND aws.vpc.flow.action IS NOT NULL
-            - STATS flow_count = COUNT() BY aws.vpc.flow.action, time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)
-            - SORT time_bucket ASC
-          mode: stacked
-          dimension:
-            field: time_bucket
-          metrics:
-            - field: flow_count
-              label: Flow Count
-          breakdown:
-            field: aws.vpc.flow.action
-          color:
-            palette: eui_amsterdam_color_blind
-            assignments:
-              - value: REJECT
-                color: '#BD271E'
-              - value: ACCEPT
-                color: '#00BF6F'
-          appearance:
-            x_axis:
-              title: '@timestamp'
-            y_left_axis:
-              title: Flow Count
-      - title: Bandwidth Usage Over Time
-        size: {w: 48, h: 12}
-        position: {x: 0, y: 31}
-        esql:
-          type: line
-          query:
-            - FROM logs-*
-            - WHERE data_stream.dataset == "aws.vpcflow.otel" AND aws.vpc.flow.bytes IS NOT NULL
-            - STATS total_bytes = SUM(aws.vpc.flow.bytes) BY time_bucket = BUCKET(@timestamp, 50, ?_tstart, ?_tend)
-            - SORT time_bucket ASC
-          dimension:
-            field: time_bucket
-          metrics:
-            - field: total_bytes
-              label: Bytes
-              format:
-                type: bytes
-          appearance:
-            x_axis:
-              title: '@timestamp'
-            y_left_axis:
-              title: Bandwidth
-
-      # Section 4: Volume Change Detection (y:43-56)
+      # Volume Change Detection
       - markdown:
           content: '### Volume Change Detection'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 43}
+        size: {w: 48, h: 2}
       - title: Significant Volume Changes by Interface
         size: {w: 48, h: 12}
-        position: {x: 0, y: 44}
         esql:
           type: datatable
           query:
@@ -285,14 +293,12 @@ dashboards:
             enabled: true
             page_size: 10
 
-      # Section 5: Source Analysis (y:56-70)
+      # Source Analysis
       - markdown:
           content: '### Source Analysis'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 56}
+        size: {w: 48, h: 2}
       - title: Top Source IPs - Detailed
         size: {w: 48, h: 13}
-        position: {x: 0, y: 57}
         esql:
           type: datatable
           query:
@@ -327,14 +333,12 @@ dashboards:
             enabled: true
             page_size: 10
 
-      # Section 6: Security Deep Dive (y:70-97)
+      # Security Deep Dive
       - markdown:
           content: '### Security Deep Dive'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 70}
+        size: {w: 48, h: 2}
       - title: Rejected Traffic by Protocol
         size: {w: 24, h: 12}
-        position: {x: 0, y: 71}
         esql:
           type: bar
           query:
@@ -364,7 +368,6 @@ dashboards:
               title: Rejected Count
       - title: Top Rejected Ports
         size: {w: 24, h: 12}
-        position: {x: 24, y: 71}
         esql:
           type: bar
           query:
@@ -394,7 +397,6 @@ dashboards:
               title: Rejected Count
       - title: Detailed Rejection Logs
         size: {w: 48, h: 13}
-        position: {x: 0, y: 83}
         esql:
           type: datatable
           query:
@@ -422,14 +424,34 @@ dashboards:
             enabled: true
             page_size: 15
 
-      # Section 7: Interface Analysis (y:96-110)
+  # Dashboard 3: Interface Analysis - Per-interface and account metrics
+  - name: '[AWS VPC OTEL] Interface Analysis'
+    filters:
+      - field: data_stream.dataset
+        equals: aws.vpcflow.otel
+    controls:
+      - type: options
+        label: Cloud Account ID
+        width: medium
+        data_view: logs-*
+        field: cloud.account.id
+      - type: options
+        label: Network Interface
+        width: medium
+        data_view: logs-*
+        field: network.interface.name
+      - type: options
+        label: Action
+        width: small
+        data_view: logs-*
+        field: aws.vpc.flow.action
+    panels:
+      # Interface Analysis
       - markdown:
           content: '### Interface Analysis'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 96}
+        size: {w: 48, h: 2}
       - title: Interface Traffic Analysis
         size: {w: 48, h: 13}
-        position: {x: 0, y: 97}
         esql:
           type: bar
           query:
@@ -456,14 +478,12 @@ dashboards:
             y_left_axis:
               title: Flow Count
 
-      # Section 8: Account Analysis (y:110-124)
+      # Account Analysis
       - markdown:
           content: '### Account Analysis'
-        size: {w: 48, h: 1}
-        position: {x: 0, y: 110}
+        size: {w: 48, h: 2}
       - title: Traffic by Cloud Account
         size: {w: 48, h: 13}
-        position: {x: 0, y: 111}
         esql:
           type: datatable
           query:

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -286,17 +286,19 @@ Detailed single-container performance analysis and resource utilization.
     ```
 <!-- markdownlint-enable MD046 -->
 
-### AWS VPC Flow Logs OpenTelemetry Dashboard
+### AWS VPC Flow Logs OpenTelemetry Dashboards
 
-AWS VPC Flow Logs monitoring dashboard for OpenTelemetry data.
+AWS VPC Flow Logs monitoring dashboards for OpenTelemetry data.
 
 **Use this when:** Monitoring AWS VPC network traffic with OpenTelemetry AWS VPC Flow Logs receiver.
 
 **Note:** Based on the [Elastic integrations repository](https://github.com/elastic/integrations/tree/main/packages/aws_vpcflow_otel) dashboard. Demonstrates ES|QL queries with area charts, bar charts, and datatables. See the [README](aws_vpcflow_otel/README.md) for data requirements and panel details.
 
-#### VPC Flow Logs Overview
+Includes 3 dashboards:
 
-Network traffic analysis with accepted/rejected flow logs, top source IPs, and detailed rejection logs.
+- **VPC Flow Logs Overview** - High-level KPIs and time-series trends
+- **Traffic Analysis** - Traffic distribution, source analysis, and security deep dive
+- **Interface Analysis** - Per-interface and per-account metrics
 
 <!-- markdownlint-disable MD046 -->
 ??? example "Dashboard Definition (aws_vpcflow_otel/dashboards.yaml)"


### PR DESCRIPTION
Converts the AWS VPC Flow Logs OpenTelemetry dashboard from the Elastic integrations repository to YAML format following the disassembly guide.

Dashboard includes:
- VPC Flow reject logs data table (ES|QL)
- Total requests trend with accept/reject segmentation (ES|QL area chart)
- Top 10 source IP addresses (ES|QL bar chart)
- Informational markdown panel

Closes #648

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/strawgate/kb-yaml-to-lens/actions/runs/20837859942) | [View branch](https://github.com/strawgate/kb-yaml-to-lens/tree/claude/issue-648-20260109-0120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an AWS VPC Flow Logs OpenTelemetry example and README with usage, data requirements, controls, and three dashboards covering KPIs, traffic distribution, time-series, volume-change detection, source, security, interface, and account analyses (22 panels total).
  * Added a detailed dashboard configuration with interactive filters, multi-panel visualizations, paging, and formatting.
  * Updated docs index to include the new example (section duplicated) and simplified the view/compile workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->