### PR TITLE
feat: Add Memcached OTel dashboard with comprehensive monitoring

### DIFF
--- a/docs/content/examples/memcached_otel/01-memcached-overview.yaml
+++ b/docs/content/examples/memcached_otel/01-memcached-overview.yaml
@@ -28,7 +28,7 @@ dashboards:
           type: metric
           data_view: metrics-*
           primary:
-            aggregation: average
+            aggregation: last_value
             field: metrics.memcached.current_items
             label: Items in Cache
             format:
@@ -40,7 +40,7 @@ dashboards:
           type: metric
           data_view: metrics-*
           primary:
-            aggregation: average
+            aggregation: last_value
             field: metrics.memcached.bytes
             label: Bytes Used
             format:
@@ -52,7 +52,7 @@ dashboards:
           type: metric
           data_view: metrics-*
           primary:
-            aggregation: average
+            aggregation: last_value
             field: metrics.memcached.connections.current
             label: Active Connections
             format:
@@ -64,7 +64,7 @@ dashboards:
           type: metric
           data_view: metrics-*
           primary:
-            aggregation: average
+            aggregation: last_value
             field: metrics.memcached.threads
             label: Threads
             format:
@@ -230,15 +230,14 @@ dashboards:
           metrics:
             - formula: counter_rate(max(metrics.memcached.evictions))
               label: Evictions/sec
-      - title: Connections
+      - title: Current Connections
         position: {x: 24, y: 45}
-        size: {w: 24, h: 10}
+        size: {w: 12, h: 10}
         lens:
           type: line
           data_view: metrics-*
           legend:
-            visible: show
-            position: right
+            visible: hide
           dimension:
             field: '@timestamp'
             type: date_histogram
@@ -246,6 +245,18 @@ dashboards:
             - aggregation: average
               field: metrics.memcached.connections.current
               label: Current Connections
+      - title: New Connections Rate
+        position: {x: 36, y: 45}
+        size: {w: 12, h: 10}
+        lens:
+          type: line
+          data_view: metrics-*
+          legend:
+            visible: hide
+          dimension:
+            field: '@timestamp'
+            type: date_histogram
+          metrics:
             - formula: counter_rate(max(metrics.memcached.connections.total))
               label: New Connections/sec
       - title: Network


### PR DESCRIPTION
## Overview
Created a complete Kibana Lens dashboard for monitoring Memcached instances using the OpenTelemetry Collector's memcachedreceiver.

## Changes
- Added `docs/examples/memcached_otel/01-memcached-overview.yaml`
- Visualizes all 11 metrics from the memcachedreceiver
- Organized into 4 logical sections: Overview, Performance, Capacity & Health, Network

## Dashboard Features
- Overview section with key metrics (items, storage, connections, threads, hit ratio)
- Performance monitoring (hit ratios, operations breakdown, commands, CPU usage)
- Capacity tracking (items, storage, evictions, connections over time)
- Network traffic visualization (received/sent bytes)

## Technical Implementation
- Metric names verified against upstream OTel Contrib receiver metadata
- Uses `counter_rate()` for all monotonic metrics
- Proper attribute breakdowns for dimensional metrics
- Follows OTel naming conventions (`metrics.` prefix)
- Includes host name control for filtering

## Testing
- ✅ Dashboard compiles successfully
- ✅ All quality checks pass (`make check`)
- ✅ Verified all 11 metrics are visualized
- ✅ Verified logical grouping and appropriate visualization types

Resolves #738

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new OpenTelemetry Memcached monitoring dashboard example with comprehensive panels for real-time visibility into cache performance, storage utilization, connection management, hit ratios, CPU usage, network traffic, and system health metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->