### PR TITLE
fix: Point binary smoke test at docs/examples

### DIFF
--- a/compiler/scripts/test_binary_smoke.sh
+++ b/compiler/scripts/test_binary_smoke.sh
@@ -56,7 +56,7 @@ echo "Test 3: Compile sample YAML"
 TEMP_OUTPUT=$(mktemp -d)
 trap 'rm -rf "$TEMP_OUTPUT"' EXIT
 
-"$BINARY_PATH" compile --input-dir "$COMPILER_ROOT/inputs" --output-dir "$TEMP_OUTPUT"
+"$BINARY_PATH" compile --input-dir "$COMPILER_ROOT/../docs/examples" --output-dir "$TEMP_OUTPUT"
 
 # Verify output files exist
 if [ ! -f "$TEMP_OUTPUT/compiled_dashboards.ndjson" ]; then


### PR DESCRIPTION
Use docs/examples directory for binary smoke tests instead of the non-existent compiler/inputs directory. This ensures smoke tests pass during CI/release builds.

Fixes #808

Generated with [Claude Code](https://claude.ai/code)