### PR TITLE
docs: standardize metric-formatting-examples to use logs-*/metrics-* patterns

### DIFF
--- a/docs/examples/metric-formatting-examples.yaml
+++ b/docs/examples/metric-formatting-examples.yaml
@@ -165,7 +165,7 @@ dashboards:
           h: 8
         lens:
           type: metric
-          data_view: sales-*
+          data_view: logs-*
           primary:
             aggregation: sum
             field: transaction.amount
@@ -301,7 +301,7 @@ dashboards:
           h: 8
         lens:
           type: metric
-          data_view: network-*
+          data_view: metrics-*
           primary:
             aggregation: sum
             field: network.bytes
@@ -319,7 +319,7 @@ dashboards:
           h: 8
         lens:
           type: metric
-          data_view: sales-*
+          data_view: logs-*
           primary:
             aggregation: count
             label: Transactions
@@ -354,7 +354,7 @@ dashboards:
           h: 8
         lens:
           type: metric
-          data_view: network-*
+          data_view: metrics-*
           primary:
             aggregation: average
             field: network.bits


### PR DESCRIPTION
Replace non-standard index patterns (sales-*, network-*) with standard
observability patterns (logs-*, metrics-*) to ensure examples are runnable
by anyone using OpenTelemetry collectors or standard Elastic integrations.

Closes #815

Generated with [Claude Code](https://claude.ai/code)