### PR TITLE
fix: copy license file to docs/ to fix MkDocs build

### DIFF
--- a/docs/examples/docker_otel/01-containers-overview.yaml
+++ b/docs/examples/docker_otel/01-containers-overview.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/docker_otel

--- a/docs/examples/docker_otel/02-container-stats.yaml
+++ b/docs/examples/docker_otel/02-container-stats.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/docker_otel

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -192,7 +192,7 @@ Comprehensive host monitoring dashboards for OpenTelemetry system metrics.
 
 **Use this when:** Monitoring infrastructure with OpenTelemetry Host Metrics Receiver.
 
-**Note:** Based on the [Elastic integrations repository](https://github.com/elastic/integrations/tree/main/packages/system_otel) dashboards. Licensed under [Elastic License 2.0](../../licenses/ELASTIC-LICENSE-2.0.txt). Some advanced panels (AI-powered features, legacy visualizations) are excluded as they're not yet supported by the compiler.
+**Note:** Based on the [Elastic integrations repository](https://github.com/elastic/integrations/tree/main/packages/system_otel) dashboards. Licensed under [Elastic License 2.0](../licenses/ELASTIC-LICENSE-2.0.txt). Some advanced panels (AI-powered features, legacy visualizations) are excluded as they're not yet supported by the compiler.
 
 #### Hosts Overview
 
@@ -260,7 +260,7 @@ Docker container monitoring dashboards for OpenTelemetry metrics.
 
 **Use this when:** Monitoring Docker containers with OpenTelemetry Docker Stats Receiver.
 
-**Note:** Based on the [Elastic integrations repository](https://github.com/elastic/integrations/tree/main/packages/docker_otel) dashboards. Licensed under [Elastic License 2.0](../../licenses/ELASTIC-LICENSE-2.0.txt).
+**Note:** Based on the [Elastic integrations repository](https://github.com/elastic/integrations/tree/main/packages/docker_otel) dashboards. Licensed under [Elastic License 2.0](../licenses/ELASTIC-LICENSE-2.0.txt).
 
 #### Containers Overview
 

--- a/docs/examples/system_otel/01-hosts-overview.yaml
+++ b/docs/examples/system_otel/01-hosts-overview.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/system_otel

--- a/docs/examples/system_otel/02-host-details-overview.yaml
+++ b/docs/examples/system_otel/02-host-details-overview.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/system_otel

--- a/docs/examples/system_otel/03-host-details-metrics.yaml
+++ b/docs/examples/system_otel/03-host-details-metrics.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/system_otel

--- a/docs/examples/system_otel/04-host-details-metadata.yaml
+++ b/docs/examples/system_otel/04-host-details-metadata.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/system_otel

--- a/docs/examples/system_otel/05-host-details-logs.yaml
+++ b/docs/examples/system_otel/05-host-details-logs.yaml
@@ -2,7 +2,7 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-# See ../../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
+# See ../../licenses/ELASTIC-LICENSE-2.0.txt for the full license text.
 #
 # This file is derived from the Elastic integrations repository:
 # https://github.com/elastic/integrations/tree/main/packages/system_otel

--- a/docs/licenses/ELASTIC-LICENSE-2.0.txt
+++ b/docs/licenses/ELASTIC-LICENSE-2.0.txt
@@ -1,0 +1,91 @@
+Elastic License 2.0
+
+Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject
+to the limitations and conditions below.
+
+Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's trademarks
+is subject to applicable law.
+
+Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+"You" refers to the individual or entity agreeing to these terms.
+
+"Your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+"Control" means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
+
+"Your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"Use" means anything you do with the software requiring one of your licenses.
+
+"Trademark" means trademarks, service marks, and similar rights.

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -28,3 +28,9 @@ These files have been converted from Kibana JSON format to YAML format for use a
 ## Other Examples
 
 All other example files in this repository (e.g., `docs/examples/aerospike/`, `docs/examples/controls-example.yaml`, etc.) are original works licensed under the project's MIT license.
+
+## Documentation Copy
+
+For documentation build purposes, a copy of `ELASTIC-LICENSE-2.0.txt` is maintained at `docs/licenses/ELASTIC-LICENSE-2.0.txt`. This allows the license to be referenced in the MkDocs documentation site.
+
+If you update the license file, ensure both copies are updated.


### PR DESCRIPTION
## Summary

- Copy license file to `docs/licenses/` directory for MkDocs access
- Update links in `docs/examples/index.md` to use correct relative path
- Update license header comments in 7 YAML example files
- Add documentation copy note to `licenses/README.md`

Fixes #832

## Test plan

- [ ] Run `make docs-build-strict` - should pass without warnings
- [ ] Verify license links work in generated docs

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license file reference paths across example configuration and documentation files to reflect the new documentation directory structure.
  * Added Elastic License 2.0 documentation copy to the examples directory for improved accessibility.
  * Updated documentation guidelines to clarify the maintenance of license file copies across the repository.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->