### PR TITLE
docs: reorganize README for better onboarding flow

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -179,20 +179,22 @@ Advanced documentation for contributors and programmatic usage:
 ```mermaid
 graph TB
     YAML[YAML Definition]
+    KIBANA[Kibana]
 
     subgraph "Interactive Development"
         EXT[VS Code Extension]
-        YAML --> EXT
         EXT --> PREVIEW[Live Preview]
-        EXT --> KIBANA[Direct Upload to Kibana]
     end
 
     subgraph "Automation/CI"
         CLI[CLI Compiler]
-        YAML --> CLI
         CLI --> NDJSON[NDJSON Files]
-        NDJSON --> KIBANA
     end
+
+    YAML --> EXT
+    YAML --> CLI
+    EXT --> KIBANA
+    NDJSON --> KIBANA
 ```
 
 ## License


### PR DESCRIPTION
Restructures docs/index.md to prioritize getting users to their first dashboard quickly:

- Lead with VS Code Extension path (recommended) before CLI
- Integrate example YAML inline with extension setup steps
- Move Features section after Getting Started
- Clarify Python 3.12+ requirement is CLI-only
- Rename and relocate architecture diagram to 'How It Works' section
- Consolidate duplicate markdown examples

Fixes #867

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Getting Started with clearer headings and copy-pasteable setup steps, including full YAML examples.
  * Simplified and consolidated introductory sections; removed embedded diagrams and decorative visuals.
  * Rewrote "How It Works" to show a streamlined YAML → Extension/CLI → Kibana flow.
  * Migrated example dashboards into a focused "More Examples / Features" narrative and updated command/snippet references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->