### PR TITLE
fix(controls): bubble up data view references to dashboard

### DIFF
--- a/compiler/src/dashboard_compiler/dashboard/compile.py
+++ b/compiler/src/dashboard_compiler/dashboard/compile.py
@@ -45,15 +45,22 @@ def compile_dashboard_attributes(dashboard: Dashboard) -> tuple[list[KbnReferenc
         dashboard (Dashboard): The Dashboard object to compile.
 
     Returns:
-        KbnDashboardAttributes: The compiled Kibana dashboard attributes view model.
+        tuple: A tuple containing the list of references and the compiled dashboard attributes.
 
     """
-    references, panels = compile_dashboard_panels(
+    panel_references, panels = compile_dashboard_panels(
         dashboard.panels,
         layout_algorithm=dashboard.settings.layout_algorithm,
     )
 
-    return references, KbnDashboardAttributes(
+    control_group_input, control_references = compile_control_group(
+        control_settings=dashboard.settings.controls, controls=dashboard.controls
+    )
+
+    # Merge panel and control references
+    all_references = panel_references + control_references
+
+    return all_references, KbnDashboardAttributes(
         title=dashboard.name,
         description=dashboard.description or '',
         panelsJSON=panels,
@@ -66,7 +73,7 @@ def compile_dashboard_attributes(dashboard: Dashboard) -> tuple[list[KbnReferenc
         optionsJSON=compile_dashboard_options(settings=dashboard.settings),
         timeRestore=False,
         version=1,
-        controlGroupInput=compile_control_group(control_settings=dashboard.settings.controls, controls=dashboard.controls),
+        controlGroupInput=control_group_input,
     )
 
 


### PR DESCRIPTION
## Summary
- Fixed controls to bubble up data view references to dashboard's references array
- Keeps `dataViewId` in explicitInput (compatible with Kibana 8.18)
- Added 4 tests to prevent future regressions

Fixes #877

## Test plan
- [ ] Verify compiled dashboards have control references in the references array
- [ ] Test controls work correctly in Kibana

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal control compilation to properly track and propagate data view references throughout the dashboard compilation flow.

* **Tests**
  * Added tests to verify correct reference handling across control types, ensuring data view associations are properly maintained during compilation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->