### PR TITLE
fix(esql): use empty kuery for panel state query instead of ESQL query

### DIFF
--- a/compiler/src/dashboard_compiler/panels/charts/compile.py
+++ b/compiler/src/dashboard_compiler/panels/charts/compile.py
@@ -235,7 +235,7 @@ def compile_esql_chart_state(panel: ESQLPanel) -> tuple[KbnLensPanelState, str]:
 
     panel_state = KbnLensPanelState(
         visualization=visualization_state,
-        query=compile_esql_query(chart.query),
+        query=KbnQuery(query='', language='kuery'),
         filters=[],
         datasourceStates=datasource_states,
         internalReferences=[],

--- a/compiler/tests/panels/charts/xy/test_xy_e2e.py
+++ b/compiler/tests/panels/charts/xy/test_xy_e2e.py
@@ -84,9 +84,9 @@ dashboards:
         }
     )
 
-    # Verify the query
+    # Verify the query (ESQL panels have empty kuery at state.query level)
     query_state = panel['embeddableConfig']['attributes']['state']['query']
-    assert query_state['esql'] == 'FROM logs-* | STATS count() BY @timestamp'
+    assert query_state == {'language': 'kuery', 'query': ''}
 
 
 def test_esql_bar_chart_e2e(tmp_path: Path) -> None:
@@ -161,9 +161,9 @@ dashboards:
         }
     )
 
-    # Verify the query
+    # Verify the query (ESQL panels have empty kuery at state.query level)
     query_state = panel['embeddableConfig']['attributes']['state']['query']
-    assert query_state['esql'] == 'FROM metrics-* | STATS count() BY @timestamp, aerospike.namespace.name'
+    assert query_state == {'language': 'kuery', 'query': ''}
 
 
 def test_esql_area_chart_e2e(tmp_path: Path) -> None:
@@ -237,9 +237,9 @@ dashboards:
         }
     )
 
-    # Verify the query
+    # Verify the query (ESQL panels have empty kuery at state.query level)
     query_state = panel['embeddableConfig']['attributes']['state']['query']
-    assert query_state['esql'] == 'FROM metrics-* | STATS count() BY @timestamp, service.name'
+    assert query_state == {'language': 'kuery', 'query': ''}
 
 
 def test_esql_line_chart_two_metrics_e2e(tmp_path: Path) -> None:
@@ -311,6 +311,6 @@ dashboards:
         }
     )
 
-    # Verify the query
+    # Verify the query (ESQL panels have empty kuery at state.query level)
     query_state = panel['embeddableConfig']['attributes']['state']['query']
-    assert query_state['esql'] == 'FROM logs-* | STATS count(), avg(response_time) BY @timestamp'
+    assert query_state == {'language': 'kuery', 'query': ''}


### PR DESCRIPTION
Fixes #888

ESQL charts were incorrectly setting `state.query` to the ESQL query. According to Kibana's expected format, `state.query` should contain an empty kuery placeholder `{language: 'kuery', query: ''}` for ESQL panels, while the actual ESQL query should only exist in `state.datasourceStates.textBased.layers[layerId].query.esql`.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized ESQL chart query initialization across panels with a consistent empty query format, replacing per-chart query compilation.

* **Tests**
  * Updated test expectations to reflect the new query state format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->