### PR TITLE
fix: add LSP binary build targets and Windows encoding fixes

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -1,7 +1,7 @@
 # Dashboard Compiler Makefile
 # Component-specific commands for the Python compiler
 
-.PHONY: help all install ci check fix test test-coverage coverage-report test-links test-smoke lint lint-check typecheck compile upload docker-build docker-run docker-test docker-publish test-docker-smoke build-binary test-binary-smoke setup update-deps clean clean-full lint-python lint-python-check lint-yaml lint-yaml-check build publish publish-test
+.PHONY: help all install ci check fix test test-coverage coverage-report test-links test-smoke lint lint-check typecheck compile upload docker-build docker-run docker-test docker-publish test-docker-smoke build-binary test-binary-smoke build-lsp-binary test-lsp-binary-smoke setup update-deps clean clean-full lint-python lint-python-check lint-yaml lint-yaml-check build publish publish-test
 
 # Docker configuration
 DOCKER_IMAGE_NAME := kb-dashboard-compiler
@@ -61,8 +61,10 @@ help:
 	@echo "  test-docker-smoke  - Run Docker smoke tests"
 	@echo ""
 	@echo "Binary Distribution:"
-	@echo "  build-binary       - Build standalone unified binary (CLI + LSP)"
-	@echo "  test-binary-smoke  - Run binary smoke tests (CLI + LSP)"
+	@echo "  build-binary           - Build standalone unified binary (CLI + LSP)"
+	@echo "  test-binary-smoke      - Run binary smoke tests (CLI + LSP)"
+	@echo "  build-lsp-binary       - Build LSP binary for VS Code extension"
+	@echo "  test-lsp-binary-smoke  - Run LSP binary smoke tests"
 	@echo ""
 	@echo "PyPI Publishing:"
 	@echo "  build         - Build package for PyPI"
@@ -214,6 +216,15 @@ build-binary:
 test-binary-smoke:
 	@echo "Running unified binary smoke tests..."
 	@bash scripts/test_binary_smoke.sh
+
+build-lsp-binary:
+	@echo "Building LSP binary for VS Code extension..."
+	@uv sync --group build
+	@uv run python scripts/build_binaries.py --lsp
+
+test-lsp-binary-smoke:
+	@echo "Running LSP binary smoke tests..."
+	@bash scripts/test_lsp_binary_smoke.sh
 
 # Cleaning
 clean:

--- a/compiler/scripts/build_binaries.py
+++ b/compiler/scripts/build_binaries.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Build standalone binaries for kb-dashboard using PyInstaller."""
 
+import argparse
 import platform
 import shutil
 import subprocess
@@ -18,13 +19,19 @@ def get_platform_name() -> str:
     return f'{system}-{arch}'
 
 
-def build_cli_binary(platform_name: str) -> Path:
-    """Build the unified CLI binary with LSP support."""
-    binary_name = f'kb-dashboard-{platform_name}'
+def build_binary(binary_name: str) -> Path:
+    """Build a binary with the specified name.
+
+    Args:
+        binary_name: Name for the output binary (without .exe extension on Windows)
+
+    Returns:
+        Path to the built binary
+    """
     if platform.system() == 'Windows':
         binary_name += '.exe'
 
-    print(f'Building unified binary: {binary_name}...')
+    print(f'Building binary: {binary_name}...')
 
     # Sync dependencies (LSP is now a main dependency, no extra group needed)
     subprocess.run(['uv', 'sync', '--group', 'build'], check=True, cwd=COMPILER_ROOT)  # noqa: S607
@@ -40,14 +47,34 @@ def build_cli_binary(platform_name: str) -> Path:
     # Report success
     binary_path = COMPILER_ROOT / 'dist' / binary_name
     size_mb = binary_path.stat().st_size / (1024 * 1024)
-    print(f'Built unified binary: {binary_path} ({size_mb:.1f} MB)')
+    print(f'Built binary: {binary_path} ({size_mb:.1f} MB)')
     return binary_path
 
 
+def build_cli_binary(platform_name: str) -> Path:
+    """Build the unified CLI binary with LSP support."""
+    binary_name = f'kb-dashboard-{platform_name}'
+    return build_binary(binary_name)
+
+
+def build_lsp_binary() -> Path:
+    """Build the LSP binary for VS Code extension.
+
+    This builds the same unified binary but with a fixed name expected by the
+    VS Code extension workflow.
+    """
+    return build_binary('kb-dashboard-compiler-lsp')
+
+
 def main() -> None:
-    """Build standalone unified binary for current platform."""
-    platform_name = get_platform_name()
-    print(f'Building unified binary for platform: {platform_name}')
+    """Build standalone binaries for current platform."""
+    parser = argparse.ArgumentParser(description='Build standalone binaries for kb-dashboard')
+    parser.add_argument(
+        '--lsp',
+        action='store_true',
+        help='Build LSP binary for VS Code extension (kb-dashboard-compiler-lsp)',
+    )
+    args = parser.parse_args()
 
     # Clean previous builds
     for d in ['build', 'dist']:
@@ -55,10 +82,15 @@ def main() -> None:
         if path.exists():
             shutil.rmtree(path)
 
-    # Build unified binary
-    build_cli_binary(platform_name)
-
-    print('Unified binary built successfully!')
+    if args.lsp:
+        print('Building LSP binary for VS Code extension...')
+        build_lsp_binary()
+        print('LSP binary built successfully!')
+    else:
+        platform_name = get_platform_name()
+        print(f'Building unified binary for platform: {platform_name}')
+        build_cli_binary(platform_name)
+        print('Unified binary built successfully!')
 
 
 if __name__ == '__main__':

--- a/compiler/scripts/test_lsp_binary_smoke.sh
+++ b/compiler/scripts/test_lsp_binary_smoke.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Smoke tests for LSP binary used by VS Code extension
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPILER_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Detect platform for Windows .exe extension
+SYSTEM=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$SYSTEM" in
+  msys*|mingw*|cygwin*) SYSTEM="windows" ;;
+esac
+
+BINARY_NAME="kb-dashboard-compiler-lsp"
+if [ "$SYSTEM" = "windows" ]; then
+  BINARY_NAME="${BINARY_NAME}.exe"
+fi
+
+BINARY_PATH="${BINARY_PATH:-$COMPILER_ROOT/dist/$BINARY_NAME}"
+
+if [ ! -f "$BINARY_PATH" ]; then
+  echo "Error: Binary not found at $BINARY_PATH"
+  echo "Please build the binary first with: make build-lsp-binary"
+  exit 1
+fi
+
+echo "Testing LSP binary: $BINARY_PATH"
+
+# Make binary executable
+chmod +x "$BINARY_PATH" 2>/dev/null || true
+
+# Test 1: Binary runs and shows help
+echo "Test 1: Binary runs and shows help"
+"$BINARY_PATH" --help > /dev/null
+echo "OK: Help command works"
+
+# Test 2: Version check
+echo "Test 2: Version check"
+"$BINARY_PATH" --version > /dev/null
+echo "OK: Version command works"
+
+# Test 3: LSP server responds to initialization
+echo "Test 3: LSP server responds to initialization"
+TEMP_LSP_LOG=$(mktemp)
+trap 'rm -f "$TEMP_LSP_LOG"' EXIT
+
+# Valid LSP initialize request (Content-Length required for LSP protocol)
+INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}'
+CONTENT_LENGTH=${#INIT_REQUEST}
+LSP_TIMEOUT_SECONDS=${LSP_TIMEOUT_SECONDS:-5}
+
+if command -v timeout &> /dev/null; then
+  printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST" | timeout "$LSP_TIMEOUT_SECONDS" "$BINARY_PATH" lsp > "$TEMP_LSP_LOG" 2>&1 || true
+elif command -v gtimeout &> /dev/null; then
+  printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST" | gtimeout "$LSP_TIMEOUT_SECONDS" "$BINARY_PATH" lsp > "$TEMP_LSP_LOG" 2>&1 || true
+else
+  printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST" | "$BINARY_PATH" lsp > "$TEMP_LSP_LOG" 2>&1 &
+  PID=$!
+  # Poll for process completion instead of sleeping full duration
+  for _ in $(seq 1 "$LSP_TIMEOUT_SECONDS"); do
+    if ! kill -0 "$PID" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  kill "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+fi
+
+# Check if LSP server responded with valid JSON-RPC response
+if grep -Eq '"error"\s*:' "$TEMP_LSP_LOG"; then
+  echo "Error: LSP server returned an error response"
+  cat "$TEMP_LSP_LOG"
+  exit 1
+elif grep -Eq '"jsonrpc"\s*:\s*"2\.0"' "$TEMP_LSP_LOG" && \
+   grep -Eq '"id"\s*:\s*1' "$TEMP_LSP_LOG" && \
+   grep -Eq '"result"\s*:' "$TEMP_LSP_LOG"; then
+  echo "OK: LSP server responds correctly to initialize request"
+else
+  echo "Error: LSP server did not respond correctly"
+  cat "$TEMP_LSP_LOG"
+  exit 1
+fi
+
+echo ""
+echo "All LSP binary smoke tests passed!"

--- a/compiler/src/dashboard_compiler/cli.py
+++ b/compiler/src/dashboard_compiler/cli.py
@@ -49,12 +49,16 @@ DEFAULT_INPUT_DIR = PROJECT_ROOT / 'inputs'
 DEFAULT_SCENARIO_DIR = PROJECT_ROOT / 'tests/dashboards/scenarios'
 DEFAULT_OUTPUT_DIR = PROJECT_ROOT / 'output'
 
-ICON_SUCCESS = '✓'
-ICON_ERROR = '✗'
-ICON_WARNING = '⚠'
-ICON_UPLOAD = '📤'
-ICON_DOWNLOAD = '📥'
-ICON_BROWSER = '🌐'
+# Use ASCII fallbacks on Windows to avoid encoding errors with cp1252
+# Windows console may not support Unicode characters properly
+_USE_ASCII_ICONS = sys.platform == 'win32' and not os.environ.get('PYTHONUTF8')
+
+ICON_SUCCESS = '[OK]' if _USE_ASCII_ICONS else '✓'
+ICON_ERROR = '[X]' if _USE_ASCII_ICONS else '✗'
+ICON_WARNING = '[!]' if _USE_ASCII_ICONS else '⚠'
+ICON_UPLOAD = '[^]' if _USE_ASCII_ICONS else '📤'
+ICON_DOWNLOAD = '[v]' if _USE_ASCII_ICONS else '📥'
+ICON_BROWSER = '[>]' if _USE_ASCII_ICONS else '🌐'
 
 MAX_GITHUB_ISSUE_URL_LENGTH = 8000
 


### PR DESCRIPTION
Add missing `build-lsp-binary` and `test-lsp-binary-smoke` Makefile targets for VS Code extension workflow, and fix Windows Unicode encoding errors.

Closes #879

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LSP binary support added for the VS Code extension with automated build and testing capabilities.
  * Windows users with restricted Unicode support now display ASCII-based status indicators instead of Unicode symbols for improved compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->