### PR TITLE
refactor: replace remaining grid syntax with size/position

### DIFF
--- a/compiler/tests/panels/test_compile_panels.py
+++ b/compiler/tests/panels/test_compile_panels.py
@@ -154,7 +154,7 @@ class TestDashboardReferenceBubbleUp:
                 {
                     'title': 'My Saved Search',
                     'id': 'search-panel-1',
-                    'grid': {'x': 0, 'y': 0, 'w': 24, 'h': 15},
+                    'size': {'w': 24, 'h': 15},
                     'search': {
                         'saved_search_id': 'my-saved-search',
                     },
@@ -178,7 +178,7 @@ class TestDashboardReferenceBubbleUp:
                 {
                     'title': 'Test Image',
                     'id': 'image-panel-1',
-                    'grid': {'x': 0, 'y': 0, 'w': 24, 'h': 15},
+                    'size': {'w': 24, 'h': 15},
                     'image': {
                         'from_url': 'https://example.com/image.png',
                     },

--- a/docs/advanced/color-assignments.md
+++ b/docs/advanced/color-assignments.md
@@ -23,7 +23,7 @@ dashboards:
   name: Status Monitoring
   panels:
     - title: HTTP Response Codes
-      grid: { x: 0, y: 0, w: 24, h: 15 }
+      size: {w: 24, h: 15}
       lens:
         type: pie
         data_view: "logs-*"

--- a/docs/advanced/esql-views.md
+++ b/docs/advanced/esql-views.md
@@ -32,7 +32,7 @@ dashboards:
   - name: "Application Logs"
     panels:
       - title: "Total Requests"
-        grid: { x: 0, y: 0, w: 16, h: 8 }
+        size: {w: 16, h: 8}
         esql:
           type: metric
           query:
@@ -42,7 +42,8 @@ dashboards:
             field: total
 
       - title: "Requests by Status"
-        grid: { x: 16, y: 0, w: 16, h: 8 }
+        size: {w: 16, h: 8}
+        position: {x: 16, y: 0}
         esql:
           type: pie
           query:
@@ -54,7 +55,8 @@ dashboards:
             - field: http.response.status_code
 
       - title: "Average Response Time"
-        grid: { x: 32, y: 0, w: 16, h: 8 }
+        size: {w: 16, h: 8}
+        position: {x: 32, y: 0}
         esql:
           type: metric
           query:
@@ -84,7 +86,7 @@ dashboards:
   - name: "Production Metrics"
     panels:
       - title: "Successful Requests"
-        grid: { x: 0, y: 0, w: 24, h: 8 }
+        size: {w: 24, h: 8}
         esql:
           type: metric
           query:
@@ -96,7 +98,8 @@ dashboards:
             field: count
 
       - title: "Error Rate"
-        grid: { x: 24, y: 0, w: 24, h: 8 }
+        size: {w: 24, h: 8}
+        position: {x: 24, y: 0}
         esql:
           type: metric
           query:
@@ -125,7 +128,7 @@ dashboards:
   - name: "API Dashboard"
     panels:
       - title: "Request Volume"
-        grid: { x: 0, y: 0, w: 16, h: 8 }
+        size: {w: 16, h: 8}
         esql:
           type: metric
           query:
@@ -135,7 +138,8 @@ dashboards:
             field: requests
 
       - title: "P95 Response Time"
-        grid: { x: 16, y: 0, w: 16, h: 8 }
+        size: {w: 16, h: 8}
+        position: {x: 16, y: 0}
         esql:
           type: metric
           query:
@@ -145,7 +149,8 @@ dashboards:
             field: p95
 
       - title: "Requests by Endpoint"
-        grid: { x: 32, y: 0, w: 16, h: 8 }
+        size: {w: 16, h: 8}
+        position: {x: 32, y: 0}
         esql:
           type: pie
           query:
@@ -176,7 +181,7 @@ dashboards:
   - name: "Host Metrics"
     panels:
       - title: "CPU by Host"
-        grid: { x: 0, y: 0, w: 24, h: 12 }
+        size: {w: 24, h: 12}
         esql:
           type: datatable
           query:
@@ -187,7 +192,8 @@ dashboards:
             - SORT avg_cpu DESC
 
       - title: "Memory by Host"
-        grid: { x: 24, y: 0, w: 24, h: 12 }
+        size: {w: 24, h: 12}
+        position: {x: 24, y: 0}
         esql:
           type: datatable
           query:

--- a/docs/advanced/legend-configuration.md
+++ b/docs/advanced/legend-configuration.md
@@ -21,7 +21,7 @@ dashboards:
   - name: "XY Chart with Legend"
     panels:
       - title: "Request Count by Service"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -60,7 +60,7 @@ dashboards:
   - name: "Pie Chart with Legend"
     panels:
       - title: "Traffic by Source"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: pie
           data_view: "logs-*"
@@ -96,7 +96,7 @@ dashboards:
   - name: "Heatmap with Legend"
     panels:
       - title: "Activity Heatmap"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: heatmap
           data_view: "logs-*"

--- a/docs/dashboard-decompiling-guide.md
+++ b/docs/dashboard-decompiling-guide.md
@@ -157,7 +157,7 @@ dashboards:
       # Title
 
       Content here
-  grid: {x: 0, y: 0, w: 48, h: 3}
+  size: {w: 48, h: 3}
 ```
 
 ### Lens Metric Panels
@@ -204,7 +204,8 @@ dashboards:
 
 ```yaml
 - title: Total Documents
-  grid: {x: 0, y: 3, w: 24, h: 15}
+  size: {w: 24, h: 15}
+  position: {x: 0, y: 3}
   lens:
     type: metric
     data_view: logs-*
@@ -247,7 +248,8 @@ dashboards:
 
 ```yaml
 - title: Status Breakdown
-  grid: {x: 24, y: 3, w: 24, h: 15}
+  size: {w: 24, h: 15}
+  position: {x: 24, y: 3}
   lens:
     type: pie
     data_view: logs-*
@@ -574,7 +576,8 @@ dashboards:
     description: Real-time application metrics
     panels:
       - title: Total Documents
-        grid: {x: 0, y: 3, w: 24, h: 15}
+        size: {w: 24, h: 15}
+        position: {x: 0, y: 3}
         lens:
           type: metric
           data_view: logs-*

--- a/docs/dashboard/dashboard.md
+++ b/docs/dashboard/dashboard.md
@@ -12,11 +12,7 @@ dashboards:
     panels:
       - markdown:
           content: "Welcome to the dashboard!"
-        grid:
-          x: 0
-          y: 0
-          w: 6
-          h: 3
+        size: {w: 6, h: 3}
 ```
 
 ## Complex Configuration Example
@@ -52,7 +48,7 @@ dashboards:
     panels:
       - markdown:
           content: "### Key Performance Indicators"
-        grid: { x: 0, y: 0, w: 12, h: 2 }
+        size: {w: 12, h: 2}
       - lens:
           type: metric
           primary:
@@ -60,7 +56,8 @@ dashboards:
             field: resource.attributes.host.name
           data_view: "metrics-*"
         title: "Total Hosts"
-        grid: { x: 0, y: 2, w: 4, h: 4 }
+        size: {w: 4, h: 4}
+        position: {x: 0, y: 2}
       - lens:
           type: bar
           dimension:
@@ -71,7 +68,8 @@ dashboards:
               field: resource.attributes.host.name
           data_view: "metrics-*"
         title: "Hosts by OS Type"
-        grid: { x: 4, y: 2, w: 8, h: 4 }
+        size: {w: 8, h: 4}
+        position: {x: 4, y: 2}
 ```
 
 ## Full Configuration Options

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ hand-crafting complex JSON.
              # Hello, Kibana!
 
              This is my first markdown panel.
-         grid: { x: 0, y: 0, w: 24, h: 15 }
+         size: {w: 24, h: 15}
    ```
 
    Or use snippets: type `dashboard` and press Tab to insert a template.
@@ -78,7 +78,7 @@ uv sync
      description: A simple dashboard
      panels:
        - title: Welcome
-         grid: { x: 0, y: 0, w: 24, h: 15 }
+         size: {w: 24, h: 15}
          markdown:
            content: |
              # Welcome to Kibana!
@@ -125,7 +125,7 @@ dashboards:
   panels:
     - title: Document Count
       type: lens
-      grid: { x: 0, y: 0, w: 24, h: 15 }
+      size: {w: 24, h: 15}
       index_pattern: your-index-pattern-*
       chart:
         type: metric

--- a/docs/panels/base.md
+++ b/docs/panels/base.md
@@ -166,32 +166,23 @@ panels:
   - markdown:
       content: "..."
     title: "Top Left Panel"
-    grid:
-      x: 0  # Starts at the far left
-      y: 0  # Starts at the very top
-      w: 24 # Occupies 24 out of 48 columns (half width)
-      h: 5  # Height of 5 grid units
+    size: {w: 24, h: 5}  # Half width (24 out of 48 columns), height of 5 units
+    position: {x: 0, y: 0}  # Starts at far left, very top
 
   # Verbose syntax (explicit)
   - lens:
       type: metric
       # ... lens configuration ...
     title: "Top Right Panel"
-    grid:
-      from_left: 24  # Starts at the 25th column (0-indexed)
-      from_top: 0    # Starts at the very top
-      width: 24      # Occupies the remaining 24 columns
-      height: 5      # Same height
+    size: {width: 24, height: 5}      # Remaining 24 columns, height of 5
+    position: {from_left: 24, from_top: 0}  # Starts at 25th column, very top
 
   # Mixed syntax (both forms work together)
   - markdown:
       content: "..."
     title: "Bottom Panel"
-    grid:
-      x: 0        # Shorthand for horizontal position
-      from_top: 5 # Verbose for vertical position
-      width: 48   # Verbose for full width
-      h: 10       # Shorthand for height
+    size: {width: 48, h: 10}   # Full width (48), height of 10
+    position: {x: 0, from_top: 5}  # Starts at left, 5 units from top
 ```
 
 ## Panel Types (Specific Configurations)

--- a/docs/panels/esql.md
+++ b/docs/panels/esql.md
@@ -41,7 +41,7 @@ dashboards:
   - name: "ESQL Metrics Dashboard"
     panels:
       - title: "Total Processed Events"
-        grid: { x: 0, y: 0, w: 16, h: 3 }
+        size: {w: 16, h: 3}
         esql:
           type: metric
           query: |
@@ -61,7 +61,8 @@ dashboards:
   - name: "ESQL Event Analysis"
     panels:
       - title: "Events by Type (ESQL)"
-        grid: { x: 16, y: 0, w: 32, h: 3 }
+        size: {w: 32, h: 3}
+        position: {x: 16, y: 0}
         esql:
           type: pie # Specifies an ESQLPieChart
           query: |
@@ -108,7 +109,7 @@ dashboards:
   - name: "Custom Time Field Example"
     panels:
       - title: "Events Over Time"
-        grid: { x: 0, y: 0, w: 48, h: 20 }
+        size: {w: 48, h: 20}
         esql:
           type: bar
           query: |
@@ -145,7 +146,7 @@ dashboards:
     description: "Example of ESQL metric panel with primary, secondary, and breakdown"
     panels:
       - title: "Service Performance Metrics"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         esql:
           type: metric
           query: |
@@ -185,7 +186,7 @@ dashboards:
     description: "Example of ESQL pie chart with donut appearance"
     panels:
       - title: "Error Types Distribution"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         esql:
           type: pie
           query: |
@@ -227,7 +228,7 @@ dashboards:
     description: "Example of ESQL bar chart with stacked mode"
     panels:
       - title: "Events Over Time by Category"
-        grid: { x: 0, y: 0, w: 48, h: 20 }
+        size: {w: 48, h: 20}
         esql:
           type: bar
           query: |
@@ -268,7 +269,7 @@ dashboards:
     description: "Example of ESQL line chart with breakdown"
     panels:
       - title: "Average Response Time by Service"
-        grid: { x: 0, y: 0, w: 48, h: 20 }
+        size: {w: 48, h: 20}
         esql:
           type: line
           query: |
@@ -309,7 +310,7 @@ dashboards:
     description: "Example of ESQL area chart with stacked mode"
     panels:
       - title: "Total Bytes by Host"
-        grid: { x: 0, y: 0, w: 48, h: 20 }
+        size: {w: 48, h: 20}
         esql:
           type: area
           query: |
@@ -373,7 +374,7 @@ dashboards:
     description: "Example showing various metric formatting options"
     panels:
       - title: "Formatted Metrics"
-        grid: { x: 0, y: 0, w: 48, h: 20 }
+        size: {w: 48, h: 20}
         esql:
           type: bar
           query: |
@@ -433,7 +434,7 @@ dashboards:
   - name: "Time Series with BUCKET Example"
     panels:
       - title: "Events Over Time (Hourly Buckets)"
-        grid: { x: 0, y: 0, w: 48, h: 20 }
+        size: {w: 48, h: 20}
         esql:
           type: bar
           query: |

--- a/docs/panels/heatmap.md
+++ b/docs/panels/heatmap.md
@@ -37,7 +37,7 @@ dashboards:
   - name: "Server Activity Dashboard"
     panels:
       - title: "Activity by Hour and Day"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: heatmap
           data_view: "logs-*"
@@ -63,7 +63,7 @@ dashboards:
   - name: "Customized Heatmap"
     panels:
       - title: "Response Time Heatmap"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: heatmap
           data_view: "logs-*"
@@ -101,7 +101,7 @@ dashboards:
   - name: "Hourly Traffic Pattern"
     panels:
       - title: "Traffic Intensity by Hour"
-        grid: { x: 0, y: 0, w: 48, h: 8 }
+        size: {w: 48, h: 8}
         lens:
           type: heatmap
           data_view: "logs-*"

--- a/docs/panels/lens.md
+++ b/docs/panels/lens.md
@@ -41,7 +41,7 @@ dashboards:
   - name: "Key Metrics Dashboard"
     panels:
       - title: "Total Users"
-        grid: { x: 0, y: 0, w: 16, h: 3 }
+        size: {w: 16, h: 3}
         lens:
           type: metric # Specifies a LensMetricChart
           data_view: "logs-*"
@@ -60,7 +60,8 @@ dashboards:
   - name: "Traffic Analysis"
     panels:
       - title: "Traffic by Source"
-        grid: { x: 16, y: 0, w: 32, h: 3 }
+        size: {w: 32, h: 3}
+        position: {x: 16, y: 0}
         lens:
           type: pie # Specifies a LensPieChart
           data_view: "weblogs-*"
@@ -117,7 +118,7 @@ dashboards:
     description: "Example of Lens metric panel with primary, secondary, and breakdown"
     panels:
       - title: "Data Transfer Metrics"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: metric
           data_view: "logs-*"
@@ -164,7 +165,7 @@ dashboards:
     description: "Example of Lens pie chart with appearance and legend options"
     panels:
       - title: "Disk Operations by Device"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: pie
           data_view: "metrics-*"

--- a/docs/panels/metric.md
+++ b/docs/panels/metric.md
@@ -37,7 +37,7 @@ dashboards:
   - name: "KPI Dashboard"
     panels:
       - title: "Total Hosts"
-        grid: { x: 0, y: 0, w: 12, h: 2 }
+        size: {w: 12, h: 2}
         lens:
           type: metric
           data_view: "metrics-*"
@@ -55,7 +55,7 @@ dashboards:
   - name: "Error Monitoring"
     panels:
       - title: "Error Rate"
-        grid: { x: 0, y: 0, w: 12, h: 2 }
+        size: {w: 12, h: 2}
         lens:
           type: metric
           data_view: "logs-*"
@@ -280,7 +280,7 @@ dashboards:
   - name: "Metrics with Suffixes"
     panels:
       - title: "Request Rate"
-        grid: { x: 0, y: 0, w: 12, h: 8 }
+        size: {w: 12, h: 8}
         lens:
           type: metric
           data_view: "logs-*"
@@ -292,7 +292,8 @@ dashboards:
               suffix: " req/sec"
 
       - title: "Active Users"
-        grid: { x: 12, y: 0, w: 12, h: 8 }
+        size: {w: 12, h: 8}
+        position: {x: 12, y: 0}
         lens:
           type: metric
           data_view: "logs-*"
@@ -314,7 +315,7 @@ dashboards:
   - name: "Compact Metrics"
     panels:
       - title: "Total Events (Compact)"
-        grid: { x: 0, y: 0, w: 12, h: 8 }
+        size: {w: 12, h: 8}
         lens:
           type: metric
           data_view: "logs-*"
@@ -335,7 +336,7 @@ dashboards:
   - name: "Formatted Metrics"
     panels:
       - title: "Revenue (Currency)"
-        grid: { x: 0, y: 0, w: 12, h: 8 }
+        size: {w: 12, h: 8}
         lens:
           type: metric
           data_view: "sales-*"
@@ -348,7 +349,8 @@ dashboards:
               pattern: "0,0.00"  # Comma separators, 2 decimals
 
       - title: "Success Rate"
-        grid: { x: 12, y: 0, w: 12, h: 8 }
+        size: {w: 12, h: 8}
+        position: {x: 12, y: 0}
         lens:
           type: metric
           data_view: "logs-*"
@@ -370,7 +372,7 @@ dashboards:
   - name: "Combined Formatting"
     panels:
       - title: "Bandwidth Usage"
-        grid: { x: 0, y: 0, w: 12, h: 8 }
+        size: {w: 12, h: 8}
         lens:
           type: metric
           data_view: "network-*"

--- a/docs/panels/xy.md
+++ b/docs/panels/xy.md
@@ -97,7 +97,7 @@ dashboards:
   - name: "Custom Axis Titles"
     panels:
       - title: "Request Latency Over Time"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -124,7 +124,7 @@ dashboards:
   - name: "Custom Axis Bounds"
     panels:
       - title: "CPU Usage (0-100%)"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: area
           data_view: "metrics-*"
@@ -153,7 +153,7 @@ dashboards:
   - name: "Logarithmic Scale"
     panels:
       - title: "Event Count (Log Scale)"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: bar
           data_view: "logs-*"
@@ -178,7 +178,7 @@ dashboards:
   - name: "Data Bounds Mode"
     panels:
       - title: "Response Time"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -203,7 +203,7 @@ dashboards:
   - name: "Dual Axis Chart"
     panels:
       - title: "Requests vs Response Time"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -267,7 +267,7 @@ dashboards:
   - name: "Basic Reference Line"
     panels:
       - title: "Response Time with SLA Threshold"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -295,7 +295,7 @@ dashboards:
   - name: "Styled Reference Lines"
     panels:
       - title: "CPU Usage with Multiple Thresholds"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: area
           data_view: "metrics-*"
@@ -339,7 +339,7 @@ dashboards:
   - name: "Reference Lines with Fill"
     panels:
       - title: "Error Rate with Acceptable Range"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -376,7 +376,7 @@ dashboards:
   - name: "Reference Lines with Icons"
     panels:
       - title: "Memory Usage with Limits"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: area
           data_view: "metrics-*"
@@ -414,7 +414,7 @@ dashboards:
   - name: "Multi-Metric with Thresholds"
     panels:
       - title: "Request Metrics with SLA"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: line
           data_view: "logs-*"
@@ -458,7 +458,7 @@ dashboards:
   - name: "Threshold-Aware Visualization"
     panels:
       - title: "Requests Above Threshold"
-        grid: { x: 0, y: 0, w: 24, h: 15 }
+        size: {w: 24, h: 15}
         lens:
           type: bar
           data_view: "logs-*"


### PR DESCRIPTION
Update all documentation examples and test fixtures to use modern `size` and `position` syntax instead of legacy `grid` field.

**Files updated:**
- 12 documentation files with 62 examples
- 1 test file with 2 test fixtures

Closes #881

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated panel layout configuration examples across multiple guides to reflect revised positioning syntax.
  * Changed panel configuration from a single grid specification to separate size and position fields.

* **Tests**
  * Updated test cases to align with new panel layout configuration format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->