### PR TITLE
fix: links default to same tab when options are partially set

### DIFF
--- a/compiler/src/dashboard_compiler/panels/links/compile.py
+++ b/compiler/src/dashboard_compiler/panels/links/compile.py
@@ -13,7 +13,7 @@ from dashboard_compiler.panels.links.view import (
     KbnWebLinkOptions,
 )
 from dashboard_compiler.shared.config import stable_id_generator
-from dashboard_compiler.shared.defaults import default_true
+from dashboard_compiler.shared.defaults import default_false, default_true
 from dashboard_compiler.shared.view import KbnReference
 
 
@@ -36,7 +36,7 @@ def compile_dashboard_link(order: int, *, link: DashboardLink) -> tuple[KbnRefer
 
     options: KbnDashboardLinkOptions | None = (
         KbnDashboardLinkOptions(
-            openInNewTab=default_true(link.new_tab),
+            openInNewTab=default_false(link.new_tab),
             useCurrentDateRange=default_true(link.with_time),
             useCurrentFilters=default_true(link.with_filters),
         )
@@ -80,7 +80,7 @@ def compile_url_link(order: int, *, link: UrlLink) -> KbnWebLink:
 
     options: KbnWebLinkOptions | None = (
         KbnWebLinkOptions(
-            openInNewTab=default_true(link.new_tab),
+            openInNewTab=default_false(link.new_tab),
             encodeUrl=default_true(link.encode),
         )
         if has_options

--- a/compiler/tests/panels/links/test_links.py
+++ b/compiler/tests/panels/links/test_links.py
@@ -291,3 +291,84 @@ def test_links_panel_dashboard_link_references_bubble_up() -> None:
     assert references == snapshot(
         [{'id': '71a1e537-15ed-4891-b102-4ef0f314a037', 'name': 'links-panel-1:link_link-1_dashboard', 'type': 'dashboard'}]
     )
+
+
+def test_compile_links_panel_dashboard_link_partial_options() -> None:
+    """Test dashboard link with partial options defaults to opening in same tab.
+
+    When with_time or with_filters is set but new_tab is not explicitly set,
+    the link should open in the same tab (matching Kibana's default behavior).
+    """
+    references, result = compile_links_panel_snapshot(
+        {
+            'id': '71a1e537-eb91-4b8a-bcbe-ffa0ff9c9abf',
+            'links': {
+                'layout': 'vertical',
+                'items': [
+                    {
+                        'dashboard': '71a1e537-15ed-4891-b102-4ef0f314a037',
+                        'label': 'Go to Dashboard',
+                        'id': 'f1057dc0-1132-4143-8a58-ccbc853aee46',
+                        'with_time': True,
+                    },
+                ],
+            },
+        }
+    )
+    assert references == snapshot(
+        [{'id': '71a1e537-15ed-4891-b102-4ef0f314a037', 'name': 'link_f1057dc0-1132-4143-8a58-ccbc853aee46_dashboard', 'type': 'dashboard'}]
+    )
+    assert result == snapshot(
+        {
+            'attributes': {
+                'layout': 'vertical',
+                'links': [
+                    {
+                        'label': 'Go to Dashboard',
+                        'type': 'dashboardLink',
+                        'id': 'f1057dc0-1132-4143-8a58-ccbc853aee46',
+                        'order': 0,
+                        'destinationRefName': 'link_f1057dc0-1132-4143-8a58-ccbc853aee46_dashboard',
+                        'options': {'openInNewTab': False, 'useCurrentDateRange': True, 'useCurrentFilters': True},
+                    }
+                ],
+            },
+            'enhancements': {},
+        }
+    )
+
+
+def test_compile_links_panel_url_link_encode_only() -> None:
+    """Test URL link with encode option but no new_tab defaults to same tab.
+
+    When encode is set but new_tab is not explicitly set,
+    the link should open in the same tab (matching Kibana's default behavior).
+    """
+    references, result = compile_links_panel_snapshot(
+        {
+            'links': {
+                'items': [
+                    {'url': 'https://elastic.co', 'label': 'Custom Label', 'encode': True},
+                ],
+            },
+        }
+    )
+    assert references == snapshot([])
+    assert result == snapshot(
+        {
+            'attributes': {
+                'layout': 'horizontal',
+                'links': [
+                    {
+                        'label': 'Custom Label',
+                        'type': 'externalLink',
+                        'id': IsUUID,
+                        'destination': 'https://elastic.co',
+                        'order': 0,
+                        'options': {'encodeUrl': True, 'openInNewTab': False},
+                    }
+                ],
+            },
+            'enhancements': {},
+        }
+    )


### PR DESCRIPTION
## Summary

- Fixed `openInNewTab` defaulting to `true` when `with_time` or `with_filters` is set without `new_tab`
- Now correctly defaults to `false` to match Kibana's behavior
- Added test coverage for partial options scenarios

Fixes #925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Changed default link behavior to open in the same tab when tab preference is not specified for both dashboard links and URL links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->