### PR TITLE
Support for exporting dashboards as individual JSON files

### DIFF
--- a/compiler/tests/test_cli_error_messages.py
+++ b/compiler/tests/test_cli_error_messages.py
@@ -254,7 +254,7 @@ class TestCompileYamlToJsonErrorHandling:
         empty_file = tmp_path / 'empty.yaml'
         empty_file.write_text('')
 
-        json_lines, error = compile_yaml_to_json(empty_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(empty_file)
         assert json_lines == []
         assert error is not None
         assert 'empty.yaml' in error
@@ -266,7 +266,7 @@ class TestCompileYamlToJsonErrorHandling:
         invalid_file = tmp_path / 'invalid.yaml'
         invalid_file.write_text('dashboards:\n  - name: Test\n    panels:\n      - title: Bad\n      grid: {x: 0\n')
 
-        json_lines, error = compile_yaml_to_json(invalid_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(invalid_file)
         assert json_lines == []
         assert error is not None
         assert 'YAML syntax error in invalid.yaml' in error
@@ -279,7 +279,7 @@ class TestCompileYamlToJsonErrorHandling:
         missing_key_file = tmp_path / 'missing-key.yaml'
         missing_key_file.write_text('panels:\n  - title: Test\n')
 
-        json_lines, error = compile_yaml_to_json(missing_key_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(missing_key_file)
         assert json_lines == []
         assert error is not None
         assert 'missing-key.yaml' in error
@@ -292,7 +292,7 @@ class TestCompileYamlToJsonErrorHandling:
         missing_name_file = tmp_path / 'missing-name.yaml'
         missing_name_file.write_text('dashboards:\n  - description: Test\n    panels: []\n')
 
-        json_lines, error = compile_yaml_to_json(missing_name_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(missing_name_file)
         assert json_lines == []
         assert error is not None
         assert 'missing-name.yaml' in error
@@ -304,7 +304,7 @@ class TestCompileYamlToJsonErrorHandling:
 
         nonexistent_file = tmp_path / 'nonexistent.yaml'
 
-        json_lines, error = compile_yaml_to_json(nonexistent_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(nonexistent_file)
         assert json_lines == []
         assert error is not None
         assert 'not found' in error
@@ -325,6 +325,7 @@ dashboards:
           content: Hello World
 """)
 
-        json_lines, error = compile_yaml_to_json(valid_file)
+        json_lines, dashboards, error = compile_yaml_to_json(valid_file)
         assert error is None
         assert len(json_lines) == 1
+        assert len(dashboards) == 1

--- a/compiler/tests/test_error_scenarios.py
+++ b/compiler/tests/test_error_scenarios.py
@@ -24,7 +24,7 @@ dashboards:
       - title: Bad Panel
         size: {w: 24
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot(
             "YAML syntax error in unclosed-brace.yaml at line 7, column 1: expected ',' or '}', but got '<stream end>'"
@@ -38,7 +38,7 @@ dashboards:
   - name: Test
    panels: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot(
             "YAML syntax error in invalid-indent.yaml at line 4, column 4: expected <block end>, but found '<block mapping start>'"
@@ -55,7 +55,7 @@ class TestMissingRequiredFields:
 panels:
   - title: Test
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot(
             'no-dashboards.yaml: Field is required. Your YAML file must have a "dashboards:" section at the top level.'
@@ -69,7 +69,7 @@ dashboards:
   - description: Test dashboard without name
     panels: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in no-name.yaml:
@@ -88,7 +88,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         # Title is optional with default empty string
         assert error is None
         assert len(json_lines) == 1
@@ -104,7 +104,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         # Grid is optional, will use default size and position
         assert error is None
         assert len(json_lines) == 1
@@ -121,7 +121,7 @@ dashboards:
         position: {x: 0, y: 0}
         markdown: {}
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in no-markdown-content.yaml:
@@ -144,7 +144,7 @@ dashboards:
             field: count
             id: count_id
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in no-esql-query.yaml:
@@ -163,7 +163,7 @@ dashboards:
   name: Test
   panels: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in dashboards-not-list.yaml:
@@ -179,7 +179,7 @@ dashboards:
     panels:
       title: Should be a list
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in panels-not-list.yaml:
@@ -198,7 +198,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         # Size must be a dict; non-dict values cause validation error
         assert json_lines == []
         assert error is not None
@@ -218,7 +218,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in position-coords-wrong.yaml:
@@ -235,7 +235,7 @@ dashboards:
       hide_panel_titles: "yes"
     panels: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in unknown-field.yaml:
@@ -259,7 +259,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error is not None
         assert 'negative-width.yaml' in error
@@ -278,7 +278,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error is not None
         assert 'width-too-large.yaml' in error
@@ -299,7 +299,7 @@ dashboards:
           query:
             - FROM logs-*
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         # fmt: off
         assert error == snapshot("1 validation error in invalid-chart-type.yaml:\n  • dashboards[0].panels[0].esql: Unknown type 'invalid_type'. Valid types: 'metric', 'gauge', 'heatmap', 'pie', 'line', 'bar', 'area', 'tagcloud', 'datatable', 'mosaic'")  # noqa: E501
@@ -322,7 +322,7 @@ dashboards:
             id: count_id
           query: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         # Empty query lists are accepted (no minimum length validation)
         assert error is None
         assert len(json_lines) == 1
@@ -349,7 +349,7 @@ dashboards:
         markdown:
           content: Second
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error is not None
         assert 'overlapping.yaml' in error
@@ -368,7 +368,7 @@ dashboards:
         markdown:
           content: Outside
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error is not None
         assert 'outside-grid.yaml' in error
@@ -389,7 +389,7 @@ dashboards:
         size: {w: 24, h: 12}
         position: {x: 0, y: 0}
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error is not None
         assert 'no-panel-type.yaml' in error
@@ -413,7 +413,7 @@ dashboards:
           query:
             - FROM logs-*
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         # Multiple discriminators are rejected (extra='forbid' behavior)
         assert json_lines == []
         assert error == snapshot(
@@ -436,7 +436,7 @@ dashboards:
         markdown:
           content: Hello
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot("""\
 1 validation error in single-error.yaml:
@@ -464,7 +464,7 @@ dashboards:
           breakdown:
             field: missing_required_field
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         # Deeply nested structures should compile successfully
         assert error is None
         assert len(json_lines) == 1
@@ -478,7 +478,7 @@ class TestEmptyOrMinimalFiles:
         yaml_file = tmp_path / 'empty.yaml'
         yaml_file.write_text('')
 
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot('empty.yaml: File is empty or invalid. Expected a YAML document with a "dashboards" key.')
 
@@ -487,7 +487,7 @@ class TestEmptyOrMinimalFiles:
         yaml_file = tmp_path / 'whitespace.yaml'
         yaml_file.write_text('   \n  \n   ')
 
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot('whitespace.yaml: File is empty or invalid. Expected a YAML document with a "dashboards" key.')
 
@@ -496,7 +496,7 @@ class TestEmptyOrMinimalFiles:
         yaml_file = tmp_path / 'comments-only.yaml'
         yaml_file.write_text('# This is just a comment\n# No actual content')
 
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert json_lines == []
         assert error == snapshot('comments-only.yaml: File is empty or invalid. Expected a YAML document with a "dashboards" key.')
 
@@ -512,7 +512,7 @@ dashboards:
   - name: Test @invalid
     panels: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert error is None
         assert len(json_lines) == 1
 
@@ -525,7 +525,7 @@ dashboards:
     name: Test2
     panels: []
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert error is None
         assert len(json_lines) == 1
 
@@ -542,7 +542,7 @@ dashboards:
         markdown:
           content: Hello World
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert error is None
         assert len(json_lines) == 1
 
@@ -564,6 +564,6 @@ dashboards:
         markdown:
           content: Second
 """)
-        json_lines, error = compile_yaml_to_json(yaml_file)
+        json_lines, _dashboards, error = compile_yaml_to_json(yaml_file)
         assert error is None
         assert len(json_lines) == 1

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -57,6 +57,30 @@ This will:
 - Create individual NDJSON files per scenario
 - Create a combined `compiled_dashboards.ndjson` file
 
+### Export Individual JSON Files
+
+For workflows that require individual JSON files per dashboard (e.g., Fleet integration):
+
+```bash
+kb-dashboard compile --format json --output-dir ./output
+```
+
+This will:
+
+- Create one pretty-printed JSON file per dashboard
+- Name files based on the dashboard title (sanitized for filesystem safety)
+- Set the exit code to the number of files that changed (useful for CI)
+
+The exit code feature is useful for CI pipelines to detect when YAML and JSON files are out of sync:
+
+```bash
+kb-dashboard compile --format json --output-dir ./dashboards
+if [ $? -ne 0 ]; then
+    echo "Dashboard JSON files are out of sync with YAML sources"
+    exit 1
+fi
+```
+
 ### Compile and Upload to Kibana
 
 Compile dashboards and upload them directly to Kibana:


### PR DESCRIPTION
Add support for exporting dashboards as individual pretty-printed JSON files instead of grouped NDJSON format. This is useful for Fleet integration and other workflows that require one file per dashboard.

Closes #924

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --format CLI option to switch between NDJSON (default) and individual JSON file outputs per dashboard
  * Generated JSON files use filesystem-safe filenames derived from dashboard titles
  * Exit code now reflects the number of changed files for CI integration

* **Behavior Changes**
  * Kibana uploads disabled when using --format=json output mode

* **Documentation**
  * Added guide for JSON export workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->