### PR TITLE
feat(vscode): replace Upload on Save with Open in Kibana on Save

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -83,6 +83,16 @@
         "command": "yamlDashboard.compileFolderAndUpload",
         "title": "Compile Folder and Upload to Kibana",
         "category": "YAML Dashboard"
+      },
+      {
+        "command": "yamlDashboard.enableOpenOnSave",
+        "title": "Enable Open in Kibana on Save",
+        "category": "YAML Dashboard"
+      },
+      {
+        "command": "yamlDashboard.disableOpenOnSave",
+        "title": "Disable Open in Kibana on Save",
+        "category": "YAML Dashboard"
       }
     ],
     "configuration": {
@@ -118,10 +128,10 @@
           ],
           "description": "Browser type to use when opening Kibana dashboards"
         },
-        "yamlDashboard.kibana.uploadOnSave": {
+        "yamlDashboard.kibana.openOnSave": {
           "type": "boolean",
           "default": false,
-          "description": "Automatically upload dashboard to Kibana when YAML file is saved (requires Kibana URL and credentials to be configured)"
+          "description": "Automatically upload and open dashboard in Kibana when YAML file is saved (requires Kibana URL and credentials to be configured)"
         }
       }
     },
@@ -141,6 +151,16 @@
           "when": "resourceLangId == yaml",
           "command": "yamlDashboard.openInKibana",
           "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == yaml",
+          "command": "yamlDashboard.enableOpenOnSave",
+          "group": "2_kibana"
+        },
+        {
+          "when": "resourceLangId == yaml",
+          "command": "yamlDashboard.disableOpenOnSave",
+          "group": "2_kibana"
         }
       ],
       "editor/title": [

--- a/vscode-extension/src/configService.ts
+++ b/vscode-extension/src/configService.ts
@@ -158,11 +158,11 @@ export class ConfigService {
     }
 
     /**
-     * Gets the Kibana upload on save setting.
-     * @returns True if upload on save is enabled, false otherwise
+     * Gets the Kibana open on save setting.
+     * @returns True if open on save is enabled, false otherwise
      */
-    getKibanaUploadOnSave(): boolean {
-        return ConfigService.get<boolean>('kibana.uploadOnSave', false);
+    getKibanaOpenOnSave(): boolean {
+        return ConfigService.get<boolean>('kibana.openOnSave', false);
     }
 
     /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -552,6 +552,21 @@ export async function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Register enable/disable open on save commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('yamlDashboard.enableOpenOnSave', async () => {
+            await vscode.workspace.getConfiguration('yamlDashboard').update('kibana.openOnSave', true, vscode.ConfigurationTarget.Global);
+            vscode.window.showInformationMessage('Open in Kibana on Save enabled');
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('yamlDashboard.disableOpenOnSave', async () => {
+            await vscode.workspace.getConfiguration('yamlDashboard').update('kibana.openOnSave', false, vscode.ConfigurationTarget.Global);
+            vscode.window.showInformationMessage('Open in Kibana on Save disabled');
+        })
+    );
+
     // Register compile folder and upload to Kibana command
     context.subscriptions.push(
         vscode.commands.registerCommand('yamlDashboard.compileFolderAndUpload', async (uri: vscode.Uri) => {


### PR DESCRIPTION
## Summary

- Rename `kibana.uploadOnSave` setting to `kibana.openOnSave`
- Add context menu commands to enable/disable the feature
- Update file watcher to open dashboard in browser after upload
- Use browserType setting to choose between simple and external browser

## Test plan

- [ ] Right-click a YAML file and verify "Enable/Disable Open in Kibana on Save" commands appear
- [ ] Enable the feature and save a dashboard YAML file
- [ ] Verify the dashboard opens in the browser after save

Closes #927

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to enable/disable automatic dashboard opening on file save
  * Added context menu options to quickly toggle dashboard opening behavior
  * Dashboards now automatically open in Kibana after uploading YAML files

* **Configuration**
  * Updated configuration property name from "uploadOnSave" to "openOnSave"
  * Added browser type selection for opening dashboards (in-app or external browser)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->