### PR TITLE
docs: add comprehensive docstrings to ESQL XY chart classes

### DIFF
--- a/compiler/src/dashboard_compiler/panels/charts/xy/config.py
+++ b/compiler/src/dashboard_compiler/panels/charts/xy/config.py
@@ -447,15 +447,128 @@ class LensAreaChart(BaseXYAreaChart, LensXYChartMixin):
 
 
 class ESQLBarChart(BaseXYBarChart, ESQLXYChartMixin):
-    """Represents a Bar chart configuration within a ESQL panel."""
+    """Represents a Bar chart configuration within an ES|QL panel.
+
+    Bar charts display categorical or time-series data using vertical or horizontal bars,
+    where bar height/length represents metric values. Ideal for comparing values across
+    categories or showing distributions over time.
+
+    The `field` names used in dimension, metrics, and breakdown must correspond to
+    columns returned by your ES|QL query.
+
+    Examples:
+        ES|QL bar chart with time series:
+        ```yaml
+        esql:
+          type: bar
+          query: |
+            FROM logs-*
+            | STATS count = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1 hour)
+          dimension:
+            field: "@timestamp"
+          metrics:
+            - field: "count"
+        ```
+
+        Stacked bar chart with breakdown:
+        ```yaml
+        esql:
+          type: bar
+          mode: stacked
+          query: |
+            FROM logs-*
+            | STATS count = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1 hour), service.name
+          dimension:
+            field: "@timestamp"
+          breakdown:
+            field: "service.name"
+          metrics:
+            - field: "count"
+        ```
+    """
 
 
 class ESQLLineChart(BaseXYLineChart, ESQLXYChartMixin):
-    """Represents a Line chart configuration within a ESQL panel."""
+    """Represents a Line chart configuration within an ES|QL panel.
+
+    Line charts display data points connected by lines, ideal for visualizing trends
+    and changes over time. Supports multiple metrics and optional breakdown for
+    comparing series.
+
+    The `field` names used in dimension, metrics, and breakdown must correspond to
+    columns returned by your ES|QL query.
+
+    Examples:
+        ES|QL line chart for time series:
+        ```yaml
+        esql:
+          type: line
+          query: |
+            FROM metrics-*
+            | STATS avg_cpu = AVG(system.cpu.total.pct) BY @timestamp = BUCKET(@timestamp, 5 minutes)
+          dimension:
+            field: "@timestamp"
+          metrics:
+            - field: "avg_cpu"
+        ```
+
+        Line chart with breakdown by host:
+        ```yaml
+        esql:
+          type: line
+          query: |
+            FROM metrics-*
+            | STATS avg_cpu = AVG(system.cpu.total.pct) BY @timestamp = BUCKET(@timestamp, 5 minutes), host.name
+          dimension:
+            field: "@timestamp"
+          breakdown:
+            field: "host.name"
+          metrics:
+            - field: "avg_cpu"
+        ```
+    """
 
 
 class ESQLAreaChart(BaseXYAreaChart, ESQLXYChartMixin):
-    """Represents an Area chart configuration within a ESQL panel."""
+    """Represents an Area chart configuration within an ES|QL panel.
+
+    Area charts display data with filled areas beneath the lines, useful for
+    visualizing cumulative values or showing the magnitude of trends over time.
+    Supports stacked and percentage modes for comparing proportions.
+
+    The `field` names used in dimension, metrics, and breakdown must correspond to
+    columns returned by your ES|QL query.
+
+    Examples:
+        ES|QL area chart for resource usage:
+        ```yaml
+        esql:
+          type: area
+          query: |
+            FROM metrics-*
+            | STATS avg_mem = AVG(system.memory.used.pct) BY @timestamp = BUCKET(@timestamp, 5 minutes)
+          dimension:
+            field: "@timestamp"
+          metrics:
+            - field: "avg_mem"
+        ```
+
+        Stacked area chart with percentage mode:
+        ```yaml
+        esql:
+          type: area
+          mode: percentage
+          query: |
+            FROM logs-*
+            | STATS count = COUNT(*) BY @timestamp = BUCKET(@timestamp, 1 hour), service.name
+          dimension:
+            field: "@timestamp"
+          breakdown:
+            field: "service.name"
+          metrics:
+            - field: "count"
+        ```
+    """
 
 
 class LensReferenceLineLayer(BaseChart):


### PR DESCRIPTION
Add detailed docstrings with YAML examples to ESQLBarChart, ESQLLineChart,
and ESQLAreaChart classes to improve documentation rendering.

The ESQL XY chart classes previously had minimal one-line docstrings without
examples, causing the mkdocs documentation at panels/xy/ to render poorly
in the ES|QL XY Charts section.

Fixes #932

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for XY chart configuration across Bar, Line, and Area chart types. Expanded descriptions now incorporate ES|QL-specific terminology and include practical configuration examples with YAML snippets. These updates provide clearer guidance and improved reference materials to help users better understand and effectively implement various chart configurations in their dashboard projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->