### PR TITLE
feat(cli): add --exit-non-zero-on-change flag for CI sync detection

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,17 +69,20 @@ This will:
 
 - Create one pretty-printed JSON file per dashboard
 - Name files based on the dashboard title (sanitized for filesystem safety)
-- Set the exit code to the number of files that changed (useful for CI)
 
-The exit code feature is useful for CI pipelines to detect when YAML and JSON files are out of sync:
+### CI Sync Detection
+
+Use the `--exit-non-zero-on-change` flag to detect when YAML and JSON files are out of sync in CI pipelines:
 
 ```bash
-kb-dashboard compile --format json --output-dir ./dashboards
+kb-dashboard compile --format json --output-dir ./dashboards --exit-non-zero-on-change
 if [ $? -ne 0 ]; then
     echo "Dashboard JSON files are out of sync with YAML sources"
     exit 1
 fi
 ```
+
+When this flag is enabled, the exit code equals the number of files that changed (capped at 125). By default, the command exits with code 0 on success regardless of whether files changed.
 
 ### Compile and Upload to Kibana
 


### PR DESCRIPTION
## Summary
- Add opt-in `--exit-non-zero-on-change` flag to `compile` command
- Default behavior now exits 0 on success (fixes non-CI usage)
- When enabled, exit code equals number of changed files (capped at 125)

Fixes #938

## Test plan
- [ ] Run `make check` - all tests pass
- [ ] Test `kb-dashboard compile` without flag - exits 0 on success
- [ ] Test `kb-dashboard compile --exit-non-zero-on-change` - exits with changed file count

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--exit-non-zero-on-change` CLI flag to enable CI sync detection
  * When enabled, exit code reflects the number of changed files (capped at 125) for improved CI/CD workflow control

* **Tests**
  * Updated smoke tests to verify new flag behavior

* **Documentation**
  * Added CI Sync Detection section with usage examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->