### PR TITLE
docs: simplify extension README

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -8,7 +8,7 @@ Build Kibana dashboards using simple YAML syntax with live preview and visual ed
 
 ## Features
 
-- **IntelliSense auto-complete** — Press `Ctrl/Cmd+Space` anywhere in your YAML to see available options, with live validation and hover documentation
+- **IntelliSense auto-complete** — Press `Ctrl+Space` (⌃Space on macOS) anywhere in your YAML to see available options, with live validation and hover documentation
 - **40+ code snippets** — Quickly insert panels, controls, layouts, and common patterns. Type a prefix like `panel-`, `control-`, or `layout-` and press `Tab` to expand
 - **Live preview panel** — See your dashboard update in real-time as you edit, with auto-compile on save
 - **Visual grid editor** — Drag-and-drop panel positioning for intuitive layout design
@@ -24,7 +24,7 @@ Build Kibana dashboards using simple YAML syntax with live preview and visual ed
 
 1. Create a file: `my-dashboard.yaml`
 2. Type `dashboard` + Tab to insert a starter template
-3. Press `Ctrl/Cmd+Space` to explore available options at any position
+3. Press `Ctrl+Space` (⌃Space on macOS) to explore available options at any position
 4. Save (`Ctrl/Cmd+S`) to compile and see your changes
 5. Run command: **YAML Dashboard: Preview Dashboard**
 


### PR DESCRIPTION
Reduce README from ~250 lines to ~50 lines for a cleaner marketplace appearance.

Keep essential info (features, install, quick start, commands) and link to full documentation.

Fixes #953

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote README into a concise Quick Start-focused layout for faster onboarding
  * Consolidated feature, usage, and snippet sections into a short Quick Start flow and compact Commands reference
  * Removed in-file troubleshooting and developer setup details, pointing instead to external documentation links
  * Preserved license info and consolidated related links into a concise external references section

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->