### PR TITLE
feat(controls): add default field support for ESQLQueryControl

### DIFF
--- a/compiler/src/dashboard_compiler/controls/compile.py
+++ b/compiler/src/dashboard_compiler/controls/compile.py
@@ -7,7 +7,8 @@ from dashboard_compiler.controls.config import (
     ControlSettings,
     ESQLFieldControl,
     ESQLFunctionControl,
-    ESQLQueryControl,
+    ESQLQueryMultiSelectControl,
+    ESQLQuerySingleSelectControl,
     ESQLStaticMultiSelectControl,
     ESQLStaticSingleSelectControl,
     MatchTechnique,
@@ -281,26 +282,18 @@ def compile_esql_static_multi_select_control(order: int, *, control: ESQLStaticM
 
 
 @log_compile
-def compile_esql_query_control(order: int, *, control: ESQLQueryControl) -> KbnESQLControl:
-    """Compile an ESQLQueryControl into its Kibana view model representation.
+def compile_esql_query_single_select_control(order: int, *, control: ESQLQuerySingleSelectControl) -> KbnESQLControl:
+    """Compile an ESQLQuerySingleSelectControl into its Kibana view model representation.
 
     Args:
         order (int): The order of the control in the dashboard.
-        control (ESQLQueryControl): The ESQLQueryControl object to compile.
+        control (ESQLQuerySingleSelectControl): The ESQLQuerySingleSelectControl object to compile.
 
     Returns:
         KbnESQLControl: The compiled Kibana ES|QL control view model.
 
     """
-    if control.default is None:
-        selected_options: list[str] = []
-    elif isinstance(control.default, str):
-        selected_options = [control.default]
-    elif isinstance(control.default, list):  # pyright: ignore[reportUnnecessaryIsInstance]
-        selected_options = control.default
-    else:  # pragma: no cover
-        msg = f'Unexpected default type: {type(control.default).__name__}'
-        raise TypeError(msg)
+    selected_options: list[str] = [control.default] if control.default is not None else []
 
     return KbnESQLControl(
         grow=False,
@@ -314,7 +307,39 @@ def compile_esql_query_control(order: int, *, control: ESQLQueryControl) -> KbnE
             controlType=EsqlControlType.VALUES_FROM_QUERY.value,
             title=control.label,
             selectedOptions=selected_options,
-            singleSelect=return_if(var=control.multiple, is_true=False, is_false=True, default=None),
+            singleSelect=True,
+            availableOptions=None,
+        ),
+    )
+
+
+@log_compile
+def compile_esql_query_multi_select_control(order: int, *, control: ESQLQueryMultiSelectControl) -> KbnESQLControl:
+    """Compile an ESQLQueryMultiSelectControl into its Kibana view model representation.
+
+    Args:
+        order (int): The order of the control in the dashboard.
+        control (ESQLQueryMultiSelectControl): The ESQLQueryMultiSelectControl object to compile.
+
+    Returns:
+        KbnESQLControl: The compiled Kibana ES|QL control view model.
+
+    """
+    selected_options: list[str] = control.default if control.default is not None else []
+
+    return KbnESQLControl(
+        grow=False,
+        order=order,
+        width=default_if_none(control.width, 'medium'),
+        explicitInput=KbnESQLControlExplicitInput(
+            id=control.get_id(),
+            variableName=control.variable_name,
+            variableType=control.variable_type,
+            esqlQuery=control.query,
+            controlType=EsqlControlType.VALUES_FROM_QUERY.value,
+            title=control.label,
+            selectedOptions=selected_options,
+            singleSelect=False,
             availableOptions=None,
         ),
     )
@@ -355,8 +380,11 @@ def compile_control(order: int, *, control: ControlTypes) -> tuple[KbnControlTyp
     if isinstance(control, ESQLStaticMultiSelectControl):
         return compile_esql_static_multi_select_control(order, control=control), None
 
-    if isinstance(control, ESQLQueryControl):  # pyright: ignore[reportUnnecessaryIsInstance]
-        return compile_esql_query_control(order, control=control), None
+    if isinstance(control, ESQLQuerySingleSelectControl):
+        return compile_esql_query_single_select_control(order, control=control), None
+
+    if isinstance(control, ESQLQueryMultiSelectControl):  # pyright: ignore[reportUnnecessaryIsInstance]
+        return compile_esql_query_multi_select_control(order, control=control), None
 
     # Explicit check to satisfy exhaustive checking pattern
     msg = f'Unknown control type: {type(control).__name__}'

--- a/compiler/src/dashboard_compiler/controls/config.py
+++ b/compiler/src/dashboard_compiler/controls/config.py
@@ -1,6 +1,5 @@
 """Configuration schema for controls used in a dashboard."""
 
-import warnings
 from enum import StrEnum
 from typing import Literal, Self
 
@@ -38,7 +37,8 @@ type ControlTypes = (
     | ESQLFunctionControl
     | ESQLStaticSingleSelectControl
     | ESQLStaticMultiSelectControl
-    | ESQLQueryControl
+    | ESQLQuerySingleSelectControl
+    | ESQLQueryMultiSelectControl
 )
 
 
@@ -283,8 +283,8 @@ class ESQLStaticMultiSelectControl(BaseControl):
         return self
 
 
-class ESQLQueryControl(BaseControl):
-    """Represents an ES|QL control with query-driven values.
+class ESQLQuerySingleSelectControl(BaseControl):
+    """Represents an ES|QL control with query-driven values for single selection.
 
     This control dynamically fetches available values from an ES|QL query
     to filter ES|QL visualizations via variables.
@@ -301,29 +301,33 @@ class ESQLQueryControl(BaseControl):
     query: str = Field(..., min_length=1)
     """The ES|QL query that returns the available values for this control."""
 
-    multiple: bool | None = Field(default=None)
-    """If true, allow multiple selection from the options."""
+    multiple: Literal[False] | None = Field(default=None)
+    """Must be None or False for single-select."""
 
-    default: str | list[str] | None = Field(default=None)
-    """Default selected value(s). Can be a string for single-select or list for multi-select."""
+    default: str | None = Field(default=None)
+    """Default selected value."""
 
-    @model_validator(mode='after')
-    def validate_default_multiple_consistency(self) -> Self:
-        """Warn if default shape doesn't match multiple setting."""
-        if self.default is None:
-            return self
 
-        is_list_default = isinstance(self.default, list)
-        if self.multiple is True and not is_list_default:
-            warnings.warn(
-                f'ESQLQueryControl {self.variable_name!r}: string default with multiple=True; consider using a list for consistency',
-                UserWarning,
-                stacklevel=2,
-            )
-        elif self.multiple is False and is_list_default:
-            warnings.warn(
-                f'ESQLQueryControl {self.variable_name!r}: list default with multiple=False; consider using a string for consistency',
-                UserWarning,
-                stacklevel=2,
-            )
-        return self
+class ESQLQueryMultiSelectControl(BaseControl):
+    """Represents an ES|QL control with query-driven values for multiple selection.
+
+    This control dynamically fetches available values from an ES|QL query
+    to filter ES|QL visualizations via variables.
+    """
+
+    type: Literal['esql'] = 'esql'
+
+    variable_name: str = Field(...)
+    """The name of the ES|QL variable (e.g., 'status_code')."""
+
+    variable_type: ESQLVariableType = Field(default=ESQLVariableType.VALUES, strict=False)
+    """The type of variable ('time_literal', 'fields', 'values', 'multi_values', 'functions')."""
+
+    query: str = Field(..., min_length=1)
+    """The ES|QL query that returns the available values for this control."""
+
+    multiple: Literal[True] = Field(default=True)
+    """Must be True for multi-select."""
+
+    default: list[str] | None = Field(default=None)
+    """Default selected values."""

--- a/compiler/tests/controls/test_controls.py
+++ b/compiler/tests/controls/test_controls.py
@@ -1,7 +1,6 @@
 """Test the compilation of controls from config models to view models."""
 
 import json
-import warnings
 from typing import Any
 
 import pytest
@@ -13,7 +12,6 @@ from dashboard_compiler.controls.compile import compile_control, compile_control
 from dashboard_compiler.controls.config import (
     ControlSettings,
     ControlTypes,
-    ESQLQueryControl,
     ESQLStaticMultiSelectControl,
     ESQLStaticSingleSelectControl,
     TimeSliderControl,
@@ -489,6 +487,7 @@ async def test_esql_query_control() -> None:
                 'controlType': 'VALUES_FROM_QUERY',
                 'title': 'Status Code',
                 'selectedOptions': [],
+                'singleSelect': True,
             },
         }
     )
@@ -1105,41 +1104,3 @@ async def test_esql_query_control_with_list_default() -> None:
             },
         }
     )
-
-
-async def test_esql_query_control_string_default_with_multiple_warns() -> None:
-    """Test that string default with multiple=True emits a warning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        ESQLQueryControl.model_validate(
-            {
-                'type': 'esql',
-                'variable_name': 'status_codes',
-                'variable_type': 'values',
-                'query': 'FROM logs-* | STATS count BY status | KEEP status',
-                'multiple': True,
-                'default': '200',
-            }
-        )
-        assert len(w) == 1
-        assert 'string default with multiple=True' in str(w[0].message)
-        assert 'status_codes' in str(w[0].message)
-
-
-async def test_esql_query_control_list_default_with_single_select_warns() -> None:
-    """Test that list default with multiple=False emits a warning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        ESQLQueryControl.model_validate(
-            {
-                'type': 'esql',
-                'variable_name': 'status_code',
-                'variable_type': 'values',
-                'query': 'FROM logs-* | STATS count BY status | KEEP status',
-                'multiple': False,
-                'default': ['200', '404'],
-            }
-        )
-        assert len(w) == 1
-        assert 'list default with multiple=False' in str(w[0].message)
-        assert 'status_code' in str(w[0].message)

--- a/docs/controls/config.md
+++ b/docs/controls/config.md
@@ -219,9 +219,16 @@ controls:
       show_root_heading: false
       heading_level: 5
 
-#### ES|QL Query-Driven Control (DEPRECATED)
+#### ES|QL Query-Driven Single-Select Control (DEPRECATED)
 
-::: dashboard_compiler.controls.config.ESQLQueryControl
+::: dashboard_compiler.controls.config.ESQLQuerySingleSelectControl
+    options:
+      show_root_heading: false
+      heading_level: 5
+
+#### ES|QL Query-Driven Multi-Select Control (DEPRECATED)
+
+::: dashboard_compiler.controls.config.ESQLQueryMultiSelectControl
     options:
       show_root_heading: false
       heading_level: 5


### PR DESCRIPTION
Add support for the `default` field in ESQLQueryControl to enable pre-selected values for query-driven ES|QL controls.

Closes #960

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query-driven controls split into explicit single‑select and multi‑select variants; defaults now apply appropriately for each.

* **Bug Fixes**
  * Improved handling of mismatched default types (string vs list) to prevent incorrect selections.

* **Documentation**
  * Updated docs with separate single/multi-select examples and notes about runtime default validation.

* **Tests**
  * Added tests covering string and list defaults and related behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->