### PR TITLE
fix: add x-elastic-internal-origin header for ESQL proxy API

### DIFF
--- a/compiler/src/dashboard_compiler/kibana_client.py
+++ b/compiler/src/dashboard_compiler/kibana_client.py
@@ -529,7 +529,11 @@ class KibanaClient:
 
         timeout = aiohttp.ClientTimeout(total=30)
         async with await self._post(
-            endpoint, params=params, json=request_body, headers={'Content-Type': 'application/json'}, timeout=timeout
+            endpoint,
+            params=params,
+            json=request_body,
+            headers={'Content-Type': 'application/json', 'x-elastic-internal-origin': 'kibana'},
+            timeout=timeout,
         ) as response:
             if response.status != HTTP_OK:
                 error_text = await response.text()


### PR DESCRIPTION
The Kibana console proxy API for ES|QL queries requires the `x-elastic-internal-origin: kibana` header to be present.

Fixes #972

Generated with [Claude Code](https://claude.ai/code)