### PR TITLE
fix: update example path in snapshot tests

### DIFF
--- a/compiler/tests/dashboards/test_full_dashboard_snapshots.py
+++ b/compiler/tests/dashboards/test_full_dashboard_snapshots.py
@@ -27,7 +27,7 @@ from tests.conftest import de_json_kbn_dashboard
 
 # Paths
 _project_root = Path(__file__).parent.parent.parent.parent
-_example_dir = _project_root / 'docs' / 'examples'
+_example_dir = _project_root / 'docs' / 'content' / 'examples'
 _snapshot_dir = Path(__file__).parent / 'snapshots'
 
 


### PR DESCRIPTION
## Summary

- Fixed test failure caused by incorrect path to example YAML files
- Updated path from `docs/examples` to `docs/content/examples`

Fixes #987

## Test plan

- [ ] Verify `make check` passes

Generated with [Claude Code](https://claude.ai/code)