### PR TITLE
feat: use dashboard ID for JSON format filenames

### DIFF
--- a/compiler/src/dashboard_compiler/cli_local.py
+++ b/compiler/src/dashboard_compiler/cli_local.py
@@ -350,6 +350,7 @@ def compile_dashboards(  # noqa: PLR0913, PLR0912, PLR0915
     errors: list[str] = []
     files_to_write: dict[Path, list[str]] = {}
     json_files_to_write: list[tuple[Path, str]] = []
+    json_filenames_seen: set[str] = set()
     changed_files_count = 0
 
     with create_progress() as progress:
@@ -366,7 +367,14 @@ def compile_dashboards(  # noqa: PLR0913, PLR0912, PLR0915
             if len(compiled_jsons) > 0:
                 if output_format_lower == 'json':
                     for kbn_dashboard in kbn_dashboards:
+                        if not kbn_dashboard.id:
+                            msg = f'Dashboard ID is required for JSON output: {yaml_file}'
+                            raise click.ClickException(msg)
                         safe_name = sanitize_filename(kbn_dashboard.id)
+                        if safe_name in json_filenames_seen:
+                            msg = f'Duplicate dashboard ID after sanitization: {kbn_dashboard.id}'
+                            raise click.ClickException(msg)
+                        json_filenames_seen.add(safe_name)
                         json_file = output_dir / f'{safe_name}.json'
                         pretty_json = kbn_dashboard.model_dump_json(by_alias=True, indent=2)
                         json_files_to_write.append((json_file, pretty_json))


### PR DESCRIPTION
Change `--format json` output to name files by dashboard ID instead of title. The dashboard ID is either explicitly set in YAML or auto-generated from the dashboard name.

Closes #976

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * JSON output files for compiled dashboards are now named using dashboard ID instead of dashboard title, providing more consistent and reliable file naming.

* **Documentation**
  * Updated help text and documentation to reflect the new dashboard ID-based naming scheme for JSON output files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->