### PR TITLE
fix(docs): replace invalid ORDER with SORT in ES|QL queries

### DIFF
--- a/docs/content/examples/mysql_otel/mysql-overview-esql.yaml
+++ b/docs/content/examples/mysql_otel/mysql-overview-esql.yaml
@@ -104,7 +104,7 @@ dashboards:
             - WHERE mysql.buffer_pool.usage IS NOT NULL
             - STATS usage = MAX(mysql.buffer_pool.usage) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), buffer_pool_data
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -125,7 +125,7 @@ dashboards:
             - WHERE mysql.buffer_pool.pages IS NOT NULL
             - STATS pages = MAX(mysql.buffer_pool.pages) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), buffer_pool_pages
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -144,7 +144,7 @@ dashboards:
             - WHERE mysql.buffer_pool.operations IS NOT NULL
             - STATS ops_rate = SUM(RATE(mysql.buffer_pool.operations)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), buffer_pool_operations
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -163,7 +163,7 @@ dashboards:
             - WHERE mysql.buffer_pool.page_flushes IS NOT NULL
             - STATS flush_rate = SUM(RATE(mysql.buffer_pool.page_flushes)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute))
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -182,7 +182,7 @@ dashboards:
             - WHERE mysql.row_operations IS NOT NULL
             - STATS row_ops_rate = SUM(RATE(mysql.row_operations)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), row_operations
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -201,7 +201,7 @@ dashboards:
             - WHERE mysql.page_operations IS NOT NULL
             - STATS page_ops_rate = SUM(RATE(mysql.page_operations)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), page_operations
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -220,7 +220,7 @@ dashboards:
             - WHERE mysql.operations IS NOT NULL
             - STATS ops_rate = SUM(RATE(mysql.operations)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), operations
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -239,7 +239,7 @@ dashboards:
             - WHERE mysql.double_writes IS NOT NULL
             - STATS double_writes_rate = SUM(RATE(mysql.double_writes)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), double_writes
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -261,7 +261,7 @@ dashboards:
             - WHERE mysql.handlers IS NOT NULL
             - STATS handler_rate = SUM(RATE(mysql.handlers)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), handler
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -282,7 +282,7 @@ dashboards:
             - WHERE mysql.locks IS NOT NULL
             - STATS lock_rate = SUM(RATE(mysql.locks)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), locks
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -301,7 +301,7 @@ dashboards:
             - WHERE mysql.row_locks IS NOT NULL
             - STATS row_lock_waits = MAX(mysql.row_locks) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), row_locks
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -322,7 +322,7 @@ dashboards:
             - WHERE mysql.log_operations IS NOT NULL
             - STATS log_ops_rate = SUM(RATE(mysql.log_operations)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), log_operations
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -343,7 +343,7 @@ dashboards:
             - WHERE mysql.table.io.wait.count IS NOT NULL
             - STATS table_io_wait_rate = SUM(RATE(mysql.table.io.wait.count)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), table_name
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -362,7 +362,7 @@ dashboards:
             - WHERE mysql.index.io.wait.count IS NOT NULL
             - STATS index_io_wait_rate = SUM(RATE(mysql.index.io.wait.count)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), index_name
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -383,7 +383,7 @@ dashboards:
             - WHERE mysql.opened_resources IS NOT NULL
             - STATS opened_rate = SUM(RATE(mysql.opened_resources)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), opened_resources
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -402,7 +402,7 @@ dashboards:
             - WHERE mysql.tmp_resources IS NOT NULL
             - STATS tmp_rate = SUM(RATE(mysql.tmp_resources)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), tmp_resources
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -423,7 +423,7 @@ dashboards:
             - WHERE mysql.threads IS NOT NULL
             - STATS thread_count = MAX(mysql.threads) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), threads
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -442,7 +442,7 @@ dashboards:
             - WHERE mysql.sorts IS NOT NULL
             - STATS sorts_rate = SUM(RATE(mysql.sorts)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute)), sorts
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -463,7 +463,7 @@ dashboards:
             - WHERE mysql.uptime IS NOT NULL
             - STATS uptime_sec = MAX(mysql.uptime) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)), DATE_TRUNC(1
               minute, MAX(@timestamp) + 1 minute))
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:
@@ -480,7 +480,7 @@ dashboards:
             - WHERE mysql.mysqlx_connections IS NOT NULL
             - STATS mysqlx_conn_rate = SUM(RATE(mysql.mysqlx_connections)) BY time_bucket = BUCKET(@timestamp, 50, DATE_TRUNC(1 minute, MIN(@timestamp)),
               DATE_TRUNC(1 minute, MAX(@timestamp) + 1 minute)), mysqlx_connections
-            - ORDER time_bucket ASC
+            - SORT time_bucket ASC
           dimension:
             field: time_bucket
           metrics:

--- a/docs/content/panels/esql.md
+++ b/docs/content/panels/esql.md
@@ -11,7 +11,7 @@ _For those who wield the power of Elasticsearch Query Language:_
 ```text
 FROM the indexes, data flows,
 WHERE the data goes, nobody knows.
-STATS works on numbers, ORDER shows the best,
+STATS works on numbers, SORT shows the best,
 LIMIT lets the engine rest.
 
 ESQL queries, powerful and clean,
@@ -68,7 +68,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS event_count = COUNT(*) BY event.category
-            | ORDER event_count DESC
+            | SORT event_count DESC
             | LIMIT 5
           metrics:
             - field: "event_count"
@@ -116,7 +116,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS event_count = COUNT(*) BY timestamp_bucket = BUCKET(event.created, 1 hour)
-            | ORDER timestamp_bucket ASC
+            | SORT timestamp_bucket ASC
           time_field: "event.created"  # Use event.created instead of @timestamp
           dimension:
             field: "timestamp_bucket"
@@ -193,7 +193,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS error_count = COUNT(error.code) BY error_type
-            | ORDER error_count DESC
+            | SORT error_count DESC
             | LIMIT 10
           metrics:
             - field: "error_count"
@@ -235,7 +235,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS event_count = COUNT(*) BY timestamp_bucket = BUCKET(@timestamp, 1 hour), event.category
-            | ORDER timestamp_bucket ASC
+            | SORT timestamp_bucket ASC
           mode: stacked
           dimension:
             field: "timestamp_bucket"
@@ -276,7 +276,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS avg_response_time = AVG(response.time) BY timestamp_bucket = BUCKET(@timestamp, 1 hour), service.name
-            | ORDER timestamp_bucket ASC
+            | SORT timestamp_bucket ASC
           dimension:
             field: "timestamp_bucket"
           metrics:
@@ -317,7 +317,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS bytes_total = SUM(bytes) BY timestamp_bucket = BUCKET(@timestamp, 1 hour), host.name
-            | ORDER timestamp_bucket ASC
+            | SORT timestamp_bucket ASC
           mode: stacked
           dimension:
             field: "timestamp_bucket"
@@ -385,7 +385,7 @@ dashboards:
                     avg_response_time = AVG(response.time),
                     success_rate = COUNT(status == 200) / COUNT(*) * 100,
                     precise_value = AVG(bytes) BY timestamp_bucket = BUCKET(@timestamp, 1 hour)
-            | ORDER timestamp_bucket ASC
+            | SORT timestamp_bucket ASC
           dimension:
             field: "timestamp_bucket"
           metrics:
@@ -441,7 +441,7 @@ dashboards:
           query: |
             FROM logs-*
             | STATS event_count = COUNT(*) BY time_bucket = BUCKET(@timestamp, 1 hour)
-            | ORDER time_bucket ASC
+            | SORT time_bucket ASC
           dimension:
             field: "time_bucket"
             data_type: "date"  # Tells Kibana this is a date field for proper formatting


### PR DESCRIPTION
Replace all instances of the invalid ES|QL `ORDER` command with the valid
`SORT` command across documentation and examples:

- mysql-overview-esql.yaml: 20 instances fixed
- esql.md: 9 instances fixed

Fixes #1018

Generated with [Claude Code](https://claude.ai/code)