### PR TITLE
docs: add markdown header minimum height guidance

### DIFF
--- a/docs/content/dashboard-style-guide.md
+++ b/docs/content/dashboard-style-guide.md
@@ -377,6 +377,10 @@ sync_tooltips: false
 - Metric cards: 8 grid units
 - Charts: 12-15 grid units
 - Tables: 15-20 grid units (allow for pagination)
+- Markdown headers (at default font_size 12):
+  - Headers h4-h6: 2 grid units
+  - Headers h1-h3: 3 grid units
+  - Header with one line of text below: 5 grid units
 
 ### Panel Ordering
 


### PR DESCRIPTION
Add guidance for minimum panel heights when using markdown panels as section headers. At the default font_size of 12:

- Headers h4-h6 require 2 grid units
- Headers h1-h3 require 3 grid units
- Headers with text below require 5 grid units

Closes #1029

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Markdown header sizing guidance to the dashboard style guide with specific grid-unit requirements for different header levels and positioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->