### PR TITLE
fix: correct OTel dashboard attribute names and aggregations

### DIFF
--- a/docs/content/examples/elasticsearch_otel/01-cluster-overview.yaml
+++ b/docs/content/examples/elasticsearch_otel/01-cluster-overview.yaml
@@ -105,19 +105,19 @@ dashboards:
               size: 20
           metrics:
             - id: active_primary
-              formula: "max(elasticsearch.cluster.shards, kql='shard_state: active_primary')"
+              formula: "max(elasticsearch.cluster.shards, kql='state: active_primary')"
               label: Active Primary
             - id: active
-              formula: "max(elasticsearch.cluster.shards, kql='shard_state: active')"
+              formula: "max(elasticsearch.cluster.shards, kql='state: active')"
               label: Active Shards
             - id: initializing
-              formula: "max(elasticsearch.cluster.shards, kql='shard_state: initializing')"
+              formula: "max(elasticsearch.cluster.shards, kql='state: initializing')"
               label: Initializing
             - id: relocating
-              formula: "max(elasticsearch.cluster.shards, kql='shard_state: relocating')"
+              formula: "max(elasticsearch.cluster.shards, kql='state: relocating')"
               label: Relocating
             - id: unassigned
-              formula: "max(elasticsearch.cluster.shards, kql='shard_state: unassigned')"
+              formula: "max(elasticsearch.cluster.shards, kql='state: unassigned')"
               label: Unassigned
       - title: Pending Tasks
         size: {w: 16, h: 8}
@@ -185,13 +185,13 @@ dashboards:
             field: '@timestamp'
             type: date_histogram
           metrics:
-            - formula: "max(elasticsearch.cluster.shards, kql='shard_state: active_primary')"
+            - formula: "max(elasticsearch.cluster.shards, kql='state: active_primary')"
               label: Active Primary
-            - formula: "max(elasticsearch.cluster.shards, kql='shard_state: active')"
+            - formula: "max(elasticsearch.cluster.shards, kql='state: active')"
               label: Active
-            - formula: "max(elasticsearch.cluster.shards, kql='shard_state: initializing')"
+            - formula: "max(elasticsearch.cluster.shards, kql='state: initializing')"
               label: Initializing
-            - formula: "max(elasticsearch.cluster.shards, kql='shard_state: relocating')"
+            - formula: "max(elasticsearch.cluster.shards, kql='state: relocating')"
               label: Relocating
-            - formula: "max(elasticsearch.cluster.shards, kql='shard_state: unassigned')"
+            - formula: "max(elasticsearch.cluster.shards, kql='state: unassigned')"
               label: Unassigned

--- a/docs/content/examples/postgresql_otel/02-overview-esql.yaml
+++ b/docs/content/examples/postgresql_otel/02-overview-esql.yaml
@@ -19,9 +19,9 @@ dashboards:
         data_view: metrics-*
         field: resource.attributes.postgresql.database.name
       - type: options
-        label: Host Name
+        label: Instance
         data_view: metrics-*
-        field: resource.attributes.host.name
+        field: resource.attributes.service.instance.id
     filters:
       - field: data_stream.dataset
         equals: postgresqlreceiver.otel
@@ -289,10 +289,10 @@ dashboards:
             - FROM metrics-*
             - WHERE data_stream.dataset == "postgresqlreceiver.otel"
             - WHERE resource.attributes.postgresql.database.name IS NOT NULL
-            - STATS BY database = resource.attributes.postgresql.database.name, host = resource.attributes.host.name
-            - KEEP database, host
+            - STATS BY database = resource.attributes.postgresql.database.name, instance = resource.attributes.service.instance.id
+            - KEEP database, instance
             - SORT database ASC
             - LIMIT 100
           dimensions:
             - field: database
-            - field: host
+            - field: instance

--- a/docs/content/examples/postgresql_otel/README.md
+++ b/docs/content/examples/postgresql_otel/README.md
@@ -26,7 +26,7 @@ ES|QL-based overview dashboard using the `TS` (time series) command for optimize
 - **Distribution Charts**:
   - Database sizes (pie chart)
   - Connection states (pie chart)
-- **Metadata Table**: List of monitored databases and hosts
+- **Metadata Table**: List of monitored databases and instances
 
 **Data Source**: `metrics-*` index pattern
 **Filter**: `data_stream.dataset == "postgresqlreceiver.otel"`
@@ -49,7 +49,7 @@ ES|QL-based overview dashboard using the `TS` (time series) command for optimize
 ### Attributes
 
 - `resource.attributes.postgresql.database.name` - Database name
-- `resource.attributes.host.name` - Host name
+- `resource.attributes.service.instance.id` - PostgreSQL instance (host:port format)
 - `attributes.source` - Block I/O source (heap_hit, heap_read, idx_hit, idx_read)
 - `attributes.operation` - Operation type (ins, upd, del, hot_upd)
 - `attributes.state` - Connection state
@@ -101,7 +101,7 @@ receivers:
 The dashboard includes controls for filtering by:
 
 - **Database Name**: Filter to specific database(s)
-- **Host Name**: Filter to specific PostgreSQL host(s)
+- **Instance**: Filter to specific PostgreSQL instance(s) by host:port
 
 ## Customization
 

--- a/docs/content/examples/system_otel/03-host-details-metrics.yaml
+++ b/docs/content/examples/system_otel/03-host-details-metrics.yaml
@@ -206,9 +206,8 @@ dashboards:
             field: attributes.device
             size: 10
           metrics:
-            - aggregation: average
-              field: metrics.system.disk.operations
-              label: Operations
+            - formula: counter_rate(metrics.system.disk.operations)
+              label: Operations/sec
       - title: Disk I/O by Device
         size: {w: 24, h: 12}
         position: {x: 0, y: 57}
@@ -224,9 +223,8 @@ dashboards:
             field: attributes.device
             size: 10
           metrics:
-            - aggregation: average
-              field: metrics.system.disk.io
-              label: Bytes
+            - formula: counter_rate(metrics.system.disk.io)
+              label: Bytes/sec
               format:
                 type: bytes
       - title: Disk I/O Time by Device


### PR DESCRIPTION
Fixes verified OTel dashboard issues:

- Elasticsearch: Change `shard_state` to `state` in KQL filters
- PostgreSQL: Replace invalid `resource.attributes.host.name` with `service.instance.id`
- System: Use `counter_rate()` for disk counter metrics

Closes #1025

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example dashboards to use refined field naming conventions and improved metric calculations.

* **Example Dashboard Updates**
  * Elasticsearch: Refined shard state filter field references.
  * PostgreSQL: Updated field references and UI labels for improved instance identification.
  * System: Disk operation and I/O metrics now display as per-second rates for better performance visualization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->