### PR TITLE
fix(snippets): correct schema field names in VS Code snippets

### DIFF
--- a/packages/vscode-extension/snippets/dashboards.json
+++ b/packages/vscode-extension/snippets/dashboards.json
@@ -236,7 +236,8 @@
       "        label: ${17:Column 2}}",
       "    metrics:",
       "      - aggregation: ${18|count,sum,avg,min,max|}",
-      "        ${19:label: ${20:Metric}}"
+      "        ${19:field: ${20:numeric_field}}",
+      "        ${21:label: ${22:Metric}}"
     ],
     "description": "Add a Lens datatable with multiple columns"
   },


### PR DESCRIPTION
Fix 5 snippets with incorrect field names that don't match the Pydantic schema:

- Lens Metric Panel: change `metric:` to `primary:`
- Lens Datatable: change `columns:` to `dimensions:` and add `metrics:` section
- Control - Options List: change `title:` to `label:`
- Control - Range Slider: change `title:` to `label:`
- Control - Time Slider: change `title:` to `label:`

Fixes #1074

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Lens Metric Panel: primary metric naming updated for clearer metric selection
  * Lens Datatable: columns renamed to dimensions and a new metrics section added to support multi-metric displays
  * Controls (Options List, Range Slider, Time Slider): placeholder renamed to label for consistent UI text handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->