### PR TITLE
fix: shell propagation in make all and LICENSE symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ all:
 	fi; \
 	for component in $(COMPONENTS); do \
 		printf "Component: %s\n" "$$component"; \
-		$(MAKE) -C $$component $$target || exit 1; \
+		$(MAKE) SHELL=$(MAKE_SHELL) -C $$component $$target || exit 1; \
 	done; \
 	printf "✓ All components: %s complete\n" "$$target"
 

--- a/packages/vscode-extension/LICENSE
+++ b/packages/vscode-extension/LICENSE
@@ -1,1 +1,1 @@
-../LICENSE
+../../LICENSE


### PR DESCRIPTION
Pre-release fixes for 0.1.11:

- Fix missing `SHELL=$(MAKE_SHELL)` in component loop (Makefile:142) causing 'Bad substitution' errors
- Fix broken LICENSE symlink in vscode-extension (`../LICENSE` → `../../LICENSE`)

Closes #974

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration
  * Adjusted internal file references

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->