### PR TITLE
refactor: mark internal functions as private and simplify docstrings

### DIFF
--- a/packages/kb-dashboard-compiler/src/dashboard_compiler/lsp/grid_updater.py
+++ b/packages/kb-dashboard-compiler/src/dashboard_compiler/lsp/grid_updater.py
@@ -63,17 +63,7 @@ def _find_panel_in_document(document: CommentedMap, panel_id: str, dashboard_ind
 
 
 def _is_alias(value: CommentedMap) -> bool:
-    """Check if a CommentedMap is an alias reference.
-
-    A value is considered an alias if it has an anchor attribute with a value,
-    indicating it was defined elsewhere and referenced via alias.
-
-    Args:
-        value: The CommentedMap to check.
-
-    Returns:
-        True if the value appears to be an alias reference.
-    """
+    """Check if a CommentedMap is an alias reference."""
     anchor = getattr(value, 'anchor', None)
     return anchor is not None and anchor.value is not None
 

--- a/packages/kb-dashboard-compiler/src/dashboard_compiler/lsp/server.py
+++ b/packages/kb-dashboard-compiler/src/dashboard_compiler/lsp/server.py
@@ -116,36 +116,14 @@ def _params_to_dict(params: Any) -> dict[str, Any]:
 
 
 def _normalize_optional_str(value: str | None) -> str | None:
-    """Normalize an optional string, converting empty strings to None.
-
-    Args:
-        value: The string value or None
-
-    Returns:
-        The string if non-empty, None otherwise
-
-    Note:
-        Type safety is enforced at compile time via the type annotation.
-        Unlike _get_required_str which extracts from dict[str, Any], this function
-        has a typed parameter so runtime isinstance checks are unnecessary.
-    """
+    """Normalize an optional string, converting empty strings to None."""
     if value is None:
         return None
     return value if len(value) > 0 else None
 
 
 def _redact_url(url: str) -> str:
-    """Redact credentials from a URL for safe logging.
-
-    Removes any username:password@ portion from the URL to prevent
-    credential leakage in log files.
-
-    Args:
-        url: The URL to redact
-
-    Returns:
-        URL with credentials removed
-    """
+    """Redact credentials from a URL for safe logging."""
     parts = urlsplit(url)
     # Reconstruct the netloc without userinfo
     host = parts.hostname if parts.hostname is not None else ''

--- a/packages/kb-dashboard-compiler/src/dashboard_compiler/yaml_roundtrip.py
+++ b/packages/kb-dashboard-compiler/src/dashboard_compiler/yaml_roundtrip.py
@@ -14,11 +14,7 @@ from ruamel.yaml.comments import CommentedMap
 
 
 def _create_yaml() -> YAML:
-    """Create a configured YAML instance for round-trip operations.
-
-    Returns:
-        YAML: A configured ruamel.yaml instance with round-trip mode enabled.
-    """
+    """Create a configured YAML instance for round-trip operations."""
     yaml = YAML(typ='rt')
     yaml.preserve_quotes = True
     yaml.default_flow_style = False

--- a/packages/kb-dashboard-lint/src/dashboard_lint/cli.py
+++ b/packages/kb-dashboard-lint/src/dashboard_lint/cli.py
@@ -35,13 +35,8 @@ except PackageNotFoundError:
     __version__ = '0.0.0-dev'
 
 
-def format_violations_text(violations: list[Violation]) -> None:
-    """Format and print violations as text output.
-
-    Args:
-        violations: List of violations to format.
-
-    """
+def _format_violations_text(violations: list[Violation]) -> None:
+    """Format and print violations as text output."""
     # Group by dashboard
     by_dashboard: defaultdict[str, list[Violation]] = defaultdict(list)
     for v in violations:
@@ -70,16 +65,8 @@ def format_violations_text(violations: list[Violation]) -> None:
             console.print(f'          {v.message}')
 
 
-def format_violations_json(violations: list[Violation]) -> str:
-    """Format violations as JSON.
-
-    Args:
-        violations: List of violations to format.
-
-    Returns:
-        JSON string representation.
-
-    """
+def _format_violations_json(violations: list[Violation]) -> str:
+    """Format violations as JSON."""
     data: list[dict[str, object]] = []
     for v in violations:
         violation_data: dict[str, object] = {
@@ -99,13 +86,8 @@ def format_violations_json(violations: list[Violation]) -> str:
     return json.dumps(data, indent=2)
 
 
-def print_summary(violations: list[Violation]) -> None:
-    """Print a summary of violations by severity.
-
-    Args:
-        violations: List of violations to summarize.
-
-    """
+def _print_summary(violations: list[Violation]) -> None:
+    """Print a summary of violations by severity."""
     errors = sum(1 for v in violations if v.severity == Severity.ERROR)
     warnings = sum(1 for v in violations if v.severity == Severity.WARNING)
     infos = sum(1 for v in violations if v.severity == Severity.INFO)
@@ -220,10 +202,10 @@ def check(
 
     # Output results
     if output_format == 'json':
-        print(format_violations_json(violations))
+        print(_format_violations_json(violations))
     elif len(violations) > 0:
-        format_violations_text(violations)
-        print_summary(violations)
+        _format_violations_text(violations)
+        _print_summary(violations)
     else:
         console.print('[green]✓ No issues found![/green]')
 

--- a/packages/kb-dashboard-lint/src/dashboard_lint/config.py
+++ b/packages/kb-dashboard-lint/src/dashboard_lint/config.py
@@ -77,19 +77,7 @@ def get_effective_config(
     config: LintConfig,
     default_severity: Severity,
 ) -> tuple[bool, Severity, dict[str, Any]]:
-    """Get the effective configuration for a rule.
-
-    Merges preset defaults with user overrides.
-
-    Args:
-        rule_id: The rule ID to get configuration for.
-        config: The user's lint configuration.
-        default_severity: The rule's built-in default severity.
-
-    Returns:
-        Tuple of (enabled, severity, options).
-
-    """
+    """Get the effective configuration for a rule, merging preset defaults with user overrides."""
     # Start with defaults
     enabled = True
     severity = default_severity
@@ -123,19 +111,8 @@ def get_effective_config(
     return enabled, severity, options
 
 
-def find_config_file(start_path: Path | None = None) -> Path | None:
-    """Search for a lint configuration file.
-
-    Searches for `.dashboard-lint.yaml` in the start path and parent
-    directories up to the filesystem root.
-
-    Args:
-        start_path: Directory to start searching from. Defaults to cwd.
-
-    Returns:
-        Path to config file if found, None otherwise.
-
-    """
+def _find_config_file(start_path: Path | None = None) -> Path | None:
+    """Search for `.dashboard-lint.yaml` in the start path and parent directories."""
     if start_path is None:
         start_path = Path.cwd()
 
@@ -169,7 +146,7 @@ def load_config(path: Path | None = None) -> LintConfig:
 
     """
     if path is None:
-        path = find_config_file()
+        path = _find_config_file()
 
     if path is None:
         # No config file found, return defaults

--- a/packages/kb-dashboard-lint/src/dashboard_lint/rules/chart/dimension_missing_label.py
+++ b/packages/kb-dashboard-lint/src/dashboard_lint/rules/chart/dimension_missing_label.py
@@ -26,15 +26,7 @@ type BreakdownConfig = LensMetricPanelConfig | LensLinePanelConfig | LensBarPane
 
 
 def _get_dimension_field(dimension: BaseLensDimension) -> str:
-    """Extract the field name from a dimension object.
-
-    Args:
-        dimension: A dimension configuration object.
-
-    Returns:
-        The field name or a descriptive string.
-
-    """
+    """Extract the field name from a dimension object."""
     if isinstance(dimension, LensTermsDimension):
         return dimension.field
     if isinstance(dimension, LensMultiTermsDimension):
@@ -49,15 +41,7 @@ def _get_dimension_field(dimension: BaseLensDimension) -> str:
 
 
 def _dimension_has_empty_label(dimension: BaseLensDimension) -> bool:
-    """Check if a dimension has an empty or missing label.
-
-    Args:
-        dimension: A dimension configuration object.
-
-    Returns:
-        True if the dimension lacks a label, False otherwise.
-
-    """
+    """Check if a dimension has an empty or missing label."""
     return dimension.label is None or len(dimension.label) == 0
 
 

--- a/packages/kb-dashboard-lint/src/dashboard_lint/rules/chart/esql_where_clause.py
+++ b/packages/kb-dashboard-lint/src/dashboard_lint/rules/chart/esql_where_clause.py
@@ -39,15 +39,7 @@ type ESQLConfig = (
 
 
 def _get_query_string(query: ESQLQuery) -> str:
-    """Extract query string from an ESQLQuery.
-
-    Args:
-        query: Query object with 'root' attribute containing the query.
-
-    Returns:
-        Single string with the full query.
-
-    """
+    """Extract query string from an ESQLQuery, joining list parts with newlines."""
     root = query.root
     if isinstance(root, list):
         return '\n'.join(str(part) for part in root)

--- a/packages/kb-dashboard-lint/src/dashboard_lint/yaml_position_resolver.py
+++ b/packages/kb-dashboard-lint/src/dashboard_lint/yaml_position_resolver.py
@@ -193,16 +193,7 @@ class YamlPositionResolver:
         return current, last_key
 
     def _get_key_position(self, parent: CommentedMap, key: str) -> SourcePosition | None:
-        """Get the position of a key in a CommentedMap.
-
-        Args:
-            parent: The parent mapping.
-            key: The key to find.
-
-        Returns:
-            SourcePosition if found, None otherwise.
-
-        """
+        """Get the line/column position of a key in a mapping, or None if unavailable."""
         if not hasattr(parent, 'lc') or parent.lc is None:
             return None
 
@@ -213,16 +204,7 @@ class YamlPositionResolver:
             return None
 
     def _get_item_position(self, parent: CommentedSeq, index: int) -> SourcePosition | None:
-        """Get the position of an item in a CommentedSeq.
-
-        Args:
-            parent: The parent sequence.
-            index: The index to find.
-
-        Returns:
-            SourcePosition if found, None otherwise.
-
-        """
+        """Get the line/column position of an item in a sequence, or None if unavailable."""
         if not hasattr(parent, 'lc') or parent.lc is None:
             return None
 


### PR DESCRIPTION
Closes #1089

## Summary

- Mark internal helper functions as private (underscore prefix) in kb-dashboard-lint and kb-dashboard-compiler
- Simplify excessive docstrings on private methods to one-liners

## Changes

**kb-dashboard-lint visibility changes (4 functions):**
- `cli.py`: `format_violations_text`, `format_violations_json`, `print_summary`
- `config.py`: `find_config_file`

**kb-dashboard-compiler visibility changes (7 functions):**
- `cli_local.py`: `sanitize_filename`, `file_content_changed`, `write_ndjson`
- `panels/compile.py`: `convert_to_panel_reference`, `compute_panel_grid`, `compile_panel_shared`, `validate_no_overlapping_grids`

**Docstrings simplified (9 methods):**
- `yaml_position_resolver.py`: `_get_key_position`, `_get_item_position`
- `dimension_missing_label.py`: `_get_dimension_field`, `_dimension_has_empty_label`
- `esql_where_clause.py`: `_get_query_string`
- `yaml_roundtrip.py`: `_create_yaml`
- `lsp/server.py`: `_normalize_optional_str`, `_redact_url`
- `lsp/grid_updater.py`: `_is_alias`

## Test plan

- [x] `make compiler ci` passes
- [x] `make vscode ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted public utility functions to private across dashboard compiler and linter modules (filename sanitization, file content checking, panel grid operations, and output formatting).
  * Updated all internal call sites to use new private function naming conventions.

* **Chores**
  * Simplified documentation strings in utility functions for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->