### PR TITLE
fix(examples): standardize metric panel heights to 4 grid units

### DIFF
--- a/packages/kb-dashboard-docs/content/advanced/esql-views.md
+++ b/packages/kb-dashboard-docs/content/advanced/esql-views.md
@@ -32,7 +32,7 @@ dashboards:
   - name: "Application Logs"
     panels:
       - title: "Total Requests"
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         esql:
           type: metric
           query:
@@ -42,7 +42,7 @@ dashboards:
             field: total
 
       - title: "Requests by Status"
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         position: {x: 16, y: 0}
         esql:
           type: pie
@@ -55,7 +55,7 @@ dashboards:
             - field: http.response.status_code
 
       - title: "Average Response Time"
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         position: {x: 32, y: 0}
         esql:
           type: metric
@@ -86,7 +86,7 @@ dashboards:
   - name: "Production Metrics"
     panels:
       - title: "Successful Requests"
-        size: {w: 24, h: 8}
+        size: {w: 24, h: 4}
         esql:
           type: metric
           query:
@@ -98,7 +98,7 @@ dashboards:
             field: count
 
       - title: "Error Rate"
-        size: {w: 24, h: 8}
+        size: {w: 24, h: 4}
         position: {x: 24, y: 0}
         esql:
           type: metric
@@ -128,7 +128,7 @@ dashboards:
   - name: "API Dashboard"
     panels:
       - title: "Request Volume"
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         esql:
           type: metric
           query:
@@ -138,7 +138,7 @@ dashboards:
             field: requests
 
       - title: "P95 Response Time"
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         position: {x: 16, y: 0}
         esql:
           type: metric
@@ -149,7 +149,7 @@ dashboards:
             field: p95
 
       - title: "Requests by Endpoint"
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         position: {x: 32, y: 0}
         esql:
           type: pie

--- a/packages/kb-dashboard-docs/content/dashboard-style-guide.md
+++ b/packages/kb-dashboard-docs/content/dashboard-style-guide.md
@@ -383,7 +383,7 @@ sync_tooltips: false
 
 **Minimum Heights:**
 
-- Metric cards: 8 grid units
+- Metric cards: 4 grid units
 - Charts: 12-15 grid units
 - Tables: 15-20 grid units (allow for pagination)
 - Markdown headers (at default font_size 12):

--- a/packages/kb-dashboard-docs/content/examples/apache_otel/01-apache-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/apache_otel/01-apache-overview.yaml
@@ -48,7 +48,7 @@ dashboards:
       # Overview Metrics Row
       - title: Request Rate
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -63,7 +63,7 @@ dashboards:
               type: number
       - title: Traffic Rate
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -78,7 +78,7 @@ dashboards:
               type: bytes
       - title: Active Connections
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -94,7 +94,7 @@ dashboards:
               pattern: 0,0
       - title: CPU Load
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:

--- a/packages/kb-dashboard-docs/content/examples/docker_otel/01-containers-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/docker_otel/01-containers-overview.yaml
@@ -43,14 +43,14 @@ dashboards:
               dashboard: docker-otel-overview
             - label: Container Stats
               dashboard: docker-otel-container-stats
-      - size: {w: 6, h: 6}
+      - size: {w: 6, h: 4}
         lens:
           type: metric
           data_view: metrics-*
           primary:
             formula: unique_count(container.id, reducedTimeRange='1h')
             label: Active Containers
-      - size: {w: 6, h: 6}
+      - size: {w: 6, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/elasticsearch_otel/01-cluster-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/elasticsearch_otel/01-cluster-overview.yaml
@@ -28,7 +28,7 @@ dashboards:
               dashboard: elasticsearch-otel-cluster-metadata
       - title: Cluster Health Status
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -42,7 +42,7 @@ dashboards:
             label: Clusters
       - title: Active Clusters
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -52,7 +52,7 @@ dashboards:
             label: Clusters
       - title: Total Nodes
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -62,7 +62,7 @@ dashboards:
             label: Nodes
       - title: Data Nodes
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/elasticsearch_otel/02-node-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/elasticsearch_otel/02-node-overview.yaml
@@ -41,7 +41,7 @@ dashboards:
           content: '### Node Health'
       - title: Document Count
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -51,7 +51,7 @@ dashboards:
             label: Documents
       - title: Open Files
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -61,7 +61,7 @@ dashboards:
             label: Open Files
       - title: HTTP Connections
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -71,7 +71,7 @@ dashboards:
             label: Connections
       - title: Active Nodes
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/elasticsearch_otel/04-index-metrics.yaml
+++ b/packages/kb-dashboard-docs/content/examples/elasticsearch_otel/04-index-metrics.yaml
@@ -41,7 +41,7 @@ dashboards:
           content: '### Index Overview'
       - title: Total Indices
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -51,7 +51,7 @@ dashboards:
             label: Indices
       - title: Total Index Size
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -61,7 +61,7 @@ dashboards:
             label: Total Size
       - title: Total Segment Count
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/01-cluster-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/01-cluster-overview.yaml
@@ -43,7 +43,7 @@ dashboards:
           font_size: 14
       - title: Running Pods
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -55,7 +55,7 @@ dashboards:
               equals: '2'
       - title: Pending Pods
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -67,7 +67,7 @@ dashboards:
               equals: '1'
       - title: Failed Pods
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -79,7 +79,7 @@ dashboards:
               equals: '4'
       - title: Container Restarts
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/02-workload-health.yaml
+++ b/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/02-workload-health.yaml
@@ -47,7 +47,7 @@ dashboards:
           font_size: 14
       - title: Ready Containers
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -59,7 +59,7 @@ dashboards:
               equals: '1'
       - title: Not Ready Containers
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -71,7 +71,7 @@ dashboards:
               equals: '0'
       - title: Total Restarts
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -82,7 +82,7 @@ dashboards:
             - exists: k8s.container.restarts
       - title: Containers Restarting
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/04-batch-jobs.yaml
+++ b/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/04-batch-jobs.yaml
@@ -47,7 +47,7 @@ dashboards:
           font_size: 14
       - title: Successful Jobs
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -58,7 +58,7 @@ dashboards:
             - exists: k8s.job.name
       - title: Failed Jobs
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -69,7 +69,7 @@ dashboards:
             - exists: k8s.job.name
       - title: Active Jobs
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -80,7 +80,7 @@ dashboards:
             - exists: k8s.job.name
       - title: Active CronJobs
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/05-autoscaling.yaml
+++ b/packages/kb-dashboard-docs/content/examples/k8s_cluster_otel/05-autoscaling.yaml
@@ -47,7 +47,7 @@ dashboards:
           font_size: 14
       - title: Total HPAs
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -58,7 +58,7 @@ dashboards:
             - exists: k8s.hpa.name
       - title: Current Replicas
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -69,7 +69,7 @@ dashboards:
             - exists: k8s.hpa.name
       - title: Desired Replicas
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -80,7 +80,7 @@ dashboards:
             - exists: k8s.hpa.name
       - title: Max Replicas Limit
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/mysql_otel/mysql-overview-esql.yaml
+++ b/packages/kb-dashboard-docs/content/examples/mysql_otel/mysql-overview-esql.yaml
@@ -35,7 +35,7 @@ dashboards:
       # Overview Metrics Row (y=2, h=6)
       - title: Active Connections
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -48,7 +48,7 @@ dashboards:
             label: Active Connections
       - title: Buffer Pool Efficiency
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         description: Ratio of clean to total buffer pool pages
         esql:
           type: metric
@@ -66,7 +66,7 @@ dashboards:
               type: percent
       - title: InnoDB Operations Rate
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -79,7 +79,7 @@ dashboards:
             label: InnoDB Ops/sec
       - title: Handler Operations Rate
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:

--- a/packages/kb-dashboard-docs/content/examples/postgresql_otel/02-overview-esql.yaml
+++ b/packages/kb-dashboard-docs/content/examples/postgresql_otel/02-overview-esql.yaml
@@ -30,7 +30,7 @@ dashboards:
       # KPI Metrics Row (y=0, h=6)
       - title: Total Databases
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -43,7 +43,7 @@ dashboards:
             label: Databases
       - title: Active Connections
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         esql:
           type: metric
           query:
@@ -56,7 +56,7 @@ dashboards:
             label: Active Backends
       - title: Max Connections
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         description: Requires postgresql.connection.max metric (enable in OTel collector)
         esql:
           type: metric
@@ -70,7 +70,7 @@ dashboards:
             label: Max Connections
       - title: Database Count
         hide_title: true
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         description: Requires postgresql.database.count metric (enable in OTel collector)
         esql:
           type: metric

--- a/packages/kb-dashboard-docs/content/examples/system/02-host-details.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/02-host-details.yaml
@@ -29,7 +29,7 @@ dashboards:
           content: |
             ### [System overview](system-metrics-overview)
       - title: CPU Usage
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -40,7 +40,7 @@ dashboards:
             format:
               type: percent
       - title: Memory Usage
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -51,7 +51,7 @@ dashboards:
             format:
               type: percent
       - title: Disk I/O
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -62,7 +62,7 @@ dashboards:
             format:
               type: bytes
       - title: Inbound Traffic
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -73,7 +73,7 @@ dashboards:
             format:
               type: bytes
       - title: Outbound Traffic
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -84,7 +84,7 @@ dashboards:
             format:
               type: bytes
       - title: Load Average
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -93,7 +93,7 @@ dashboards:
             field: system.load.1
             label: Load 1m
       - title: Disk Write I/O
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -104,7 +104,7 @@ dashboards:
             format:
               type: bytes
       - title: Max Disk Usage
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/system/08-windows-logons.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/08-windows-logons.yaml
@@ -52,7 +52,7 @@ dashboards:
             field: winlog.event_id
             size: 10
       - title: Total Logon Attempts
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -65,7 +65,7 @@ dashboards:
                 - '4624'
                 - '4625'
       - title: Successful Logons
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -78,7 +78,7 @@ dashboards:
             - field: event.outcome
               equals: success
       - title: Failed Logons
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -89,7 +89,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4625'
       - title: Logoffs
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system/09-windows-failed-blocked.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/09-windows-failed-blocked.yaml
@@ -44,7 +44,7 @@ dashboards:
             field: winlog.event_id
             size: 10
       - title: Failed Logons (4625)
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -55,7 +55,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4625'
       - title: Account Lockouts (4740)
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -66,7 +66,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4740'
       - title: Account Unlocks (4767)
-        size: {w: 16, h: 8}
+        size: {w: 16, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system/10-windows-user-management.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/10-windows-user-management.yaml
@@ -54,7 +54,7 @@ dashboards:
             field: winlog.event_id
             size: 15
       - title: User Created (4720)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -65,7 +65,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4720'
       - title: User Enabled (4722)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -76,7 +76,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4722'
       - title: User Disabled (4725)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -87,7 +87,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4725'
       - title: User Deleted (4726)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system/11-windows-group-management.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/11-windows-group-management.yaml
@@ -62,7 +62,7 @@ dashboards:
             field: winlog.event_id
             size: 20
       - title: Group Created
-        size: {w: 10, h: 8}
+        size: {w: 10, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -77,7 +77,7 @@ dashboards:
                 - '4754'
                 - '4759'
       - title: Member Added
-        size: {w: 10, h: 8}
+        size: {w: 10, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -92,7 +92,7 @@ dashboards:
                 - '4756'
                 - '4761'
       - title: Group Modified
-        size: {w: 8, h: 8}
+        size: {w: 8, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -108,7 +108,7 @@ dashboards:
                 - '4760'
                 - '4764'
       - title: Member Removed
-        size: {w: 10, h: 8}
+        size: {w: 10, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -123,7 +123,7 @@ dashboards:
                 - '4757'
                 - '4762'
       - title: Group Deleted
-        size: {w: 10, h: 8}
+        size: {w: 10, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system/12-windows-directory-monitoring.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/12-windows-directory-monitoring.yaml
@@ -58,7 +58,7 @@ dashboards:
             field: winlog.event_id
             size: 15
       - title: Computer Account Changes (4742)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -69,7 +69,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4742'
       - title: Kerberos TGT Requests (4768)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -80,7 +80,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4768'
       - title: Kerberos Service Tickets (4769)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -91,7 +91,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4769'
       - title: Credential Validation (4776)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system/13-windows-system-process.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/13-windows-system-process.yaml
@@ -60,7 +60,7 @@ dashboards:
             field: winlog.event_id
             size: 15
       - title: Audit Log Cleared (1102)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -71,7 +71,7 @@ dashboards:
             - field: winlog.event_id
               equals: '1102'
       - title: Process Created (4688)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -82,7 +82,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4688'
       - title: Process Terminated (4689)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -93,7 +93,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4689'
       - title: Service Installed (4697)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system/14-windows-policy-object.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system/14-windows-policy-object.yaml
@@ -70,7 +70,7 @@ dashboards:
             field: winlog.event_id
             size: 25
       - title: Audit Policy Changes (4719)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -81,7 +81,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4719'
       - title: Registry Value Modified (4657)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -92,7 +92,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4657'
       - title: Object Access (4663)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -103,7 +103,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4663'
       - title: Task Scheduled (4698)
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/01-metrics-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/01-metrics-overview.yaml
@@ -47,7 +47,7 @@ dashboards:
 
       # Summary Layer - Key Metrics (limited to 4)
       - title: Total Hosts
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -56,7 +56,7 @@ dashboards:
             field: host.name
             label: Hosts
       - title: Average CPU Utilization
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -70,7 +70,7 @@ dashboards:
             - field: data_stream.dataset
               equals: system.cpu
       - title: Average Memory Usage
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -84,7 +84,7 @@ dashboards:
             - field: data_stream.dataset
               equals: system.memory
       - title: Average Disk Usage
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/02-host-details.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/02-host-details.yaml
@@ -51,7 +51,7 @@ dashboards:
 
       # Summary Layer - Key Host Metrics (4 metrics max)
       - title: CPU
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -65,7 +65,7 @@ dashboards:
             - field: data_stream.dataset
               equals: system.cpu
       - title: Memory
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -79,7 +79,7 @@ dashboards:
             - field: data_stream.dataset
               equals: system.memory
       - title: Disk Usage
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -93,7 +93,7 @@ dashboards:
             - field: data_stream.dataset
               equals: system.filesystem
       - title: Load Average
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/03-syslog.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/03-syslog.yaml
@@ -44,7 +44,7 @@ dashboards:
 
       # Summary Layer - Key Metrics (2 metrics for logs)
       - title: Total Events
-        size: {w: 16, h: 6}
+        size: {w: 16, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -52,7 +52,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Unique Hosts
-        size: {w: 16, h: 6}
+        size: {w: 16, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -61,7 +61,7 @@ dashboards:
             field: host.hostname
             label: Hosts
       - title: Unique Programs
-        size: {w: 16, h: 6}
+        size: {w: 16, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/04-sudo-commands.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/04-sudo-commands.yaml
@@ -43,7 +43,7 @@ dashboards:
 
       # Summary Layer - Key Security Metrics
       - title: Total Commands
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -51,7 +51,7 @@ dashboards:
             aggregation: count
             label: Commands
       - title: Unique Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -60,7 +60,7 @@ dashboards:
             field: system.auth.sudo.user
             label: Users
       - title: Unique Hosts
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -69,7 +69,7 @@ dashboards:
             field: host.hostname
             label: Hosts
       - title: Unique Commands
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/05-ssh-logins.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/05-ssh-logins.yaml
@@ -47,7 +47,7 @@ dashboards:
 
       # Summary Layer - Key Security Metrics
       - title: Total Attempts
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -55,7 +55,7 @@ dashboards:
             aggregation: count
             label: Attempts
       - title: Accepted Logins
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -66,7 +66,7 @@ dashboards:
             - field: system.auth.ssh.event
               equals: Accepted
       - title: Failed Logins
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -77,7 +77,7 @@ dashboards:
             - field: system.auth.ssh.event
               equals: Failed
       - title: Unique Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/06-users-groups.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/06-users-groups.yaml
@@ -50,7 +50,7 @@ dashboards:
 
       # Summary Layer - Key IAM Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -58,7 +58,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Unique Actions
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -67,7 +67,7 @@ dashboards:
             field: event.action
             label: Actions
       - title: Unique Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -76,7 +76,7 @@ dashboards:
             field: user.name
             label: Users
       - title: Unique Hosts
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/07-windows-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/07-windows-overview.yaml
@@ -52,7 +52,7 @@ dashboards:
 
       # Summary Layer - Key Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -60,7 +60,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Unique Event Codes
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -69,7 +69,7 @@ dashboards:
             field: event.code
             label: Event Codes
       - title: Unique Hosts
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -78,7 +78,7 @@ dashboards:
             field: host.hostname
             label: Hosts
       - title: Unique Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/08-windows-logons.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/08-windows-logons.yaml
@@ -61,7 +61,7 @@ dashboards:
 
       # Summary Layer - Key Logon Metrics
       - title: Total Logon Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -69,7 +69,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Successful Logons
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -80,7 +80,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4624'
       - title: Failed Logons
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -91,7 +91,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4625'
       - title: Logoffs
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/09-windows-failed-blocked.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/09-windows-failed-blocked.yaml
@@ -60,7 +60,7 @@ dashboards:
 
       # Summary Layer - Key Security Metrics
       - title: Total Failed Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -68,7 +68,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Failed Logons (4625)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -79,7 +79,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4625'
       - title: Account Lockouts (4740)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -90,7 +90,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4740'
       - title: Unique Affected Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/10-windows-user-management.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/10-windows-user-management.yaml
@@ -63,7 +63,7 @@ dashboards:
 
       # Summary Layer - Key Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -71,7 +71,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Users Created (4720)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -82,7 +82,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4720'
       - title: Users Deleted (4726)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -93,7 +93,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4726'
       - title: Password Changes (4723/4724)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/11-windows-group-management.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/11-windows-group-management.yaml
@@ -70,7 +70,7 @@ dashboards:
 
       # Summary Layer - Key Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -78,7 +78,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Unique Groups
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -87,7 +87,7 @@ dashboards:
             field: winlog.event_data.TargetUserName
             label: Groups
       - title: Members Added
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -101,7 +101,7 @@ dashboards:
                 - '4732'
                 - '4756'
       - title: Members Removed
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/12-windows-directory-monitoring.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/12-windows-directory-monitoring.yaml
@@ -62,7 +62,7 @@ dashboards:
 
       # Summary Layer - Key Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -70,7 +70,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Directory Service Access (4662)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -81,7 +81,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4662'
       - title: Object Modifications (5136)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -92,7 +92,7 @@ dashboards:
             - field: winlog.event_id
               equals: '5136'
       - title: Unique Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/13-windows-system-process.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/13-windows-system-process.yaml
@@ -68,7 +68,7 @@ dashboards:
 
       # Summary Layer - Key Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -76,7 +76,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Process Created (4688)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -87,7 +87,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4688'
       - title: Services Installed (7045)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -98,7 +98,7 @@ dashboards:
             - field: winlog.event_id
               equals: '7045'
       - title: Scheduled Tasks
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_modern/14-windows-policy-object.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_modern/14-windows-policy-object.yaml
@@ -67,7 +67,7 @@ dashboards:
 
       # Summary Layer - Key Metrics
       - title: Total Events
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -75,7 +75,7 @@ dashboards:
             aggregation: count
             label: Events
       - title: Unique Event Types
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -84,7 +84,7 @@ dashboards:
             field: winlog.event_id
             label: Event Types
       - title: Policy Changes (4719)
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*
@@ -95,7 +95,7 @@ dashboards:
             - field: winlog.event_id
               equals: '4719'
       - title: Unique Users
-        size: {w: 12, h: 6}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: logs-*

--- a/packages/kb-dashboard-docs/content/examples/system_otel/01-hosts-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_otel/01-hosts-overview.yaml
@@ -46,7 +46,7 @@ dashboards:
           content: '## Fleet Health'
       - title: Total Hosts
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -56,7 +56,7 @@ dashboards:
             label: Total Hosts
       - title: Hosts by OS Type
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -70,7 +70,7 @@ dashboards:
             label: Hosts
       - title: CPU Utilization Fleet
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -83,7 +83,7 @@ dashboards:
               type: percent
       - title: Memory Utilization Fleet
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/examples/system_otel/02-host-details-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/system_otel/02-host-details-overview.yaml
@@ -51,7 +51,7 @@ dashboards:
           content: '## Key Metrics'
       - title: CPU Utilization
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -64,7 +64,7 @@ dashboards:
               type: percent
       - title: Normalized Load
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -75,7 +75,7 @@ dashboards:
               type: percent
       - title: Memory Utilization
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*
@@ -86,7 +86,7 @@ dashboards:
               type: percent
       - title: Disk Usage
         hide_title: true
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: metrics-*

--- a/packages/kb-dashboard-docs/content/panels/metric.md
+++ b/packages/kb-dashboard-docs/content/panels/metric.md
@@ -283,7 +283,7 @@ dashboards:
   - name: "Metrics with Suffixes"
     panels:
       - title: "Request Rate"
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: "logs-*"
@@ -295,7 +295,7 @@ dashboards:
               suffix: " req/sec"
 
       - title: "Active Users"
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         position: {x: 12, y: 0}
         lens:
           type: metric
@@ -318,7 +318,7 @@ dashboards:
   - name: "Compact Metrics"
     panels:
       - title: "Total Events (Compact)"
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: "logs-*"
@@ -339,7 +339,7 @@ dashboards:
   - name: "Formatted Metrics"
     panels:
       - title: "Revenue (Currency)"
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: "sales-*"
@@ -352,7 +352,7 @@ dashboards:
               pattern: "0,0.00"  # Comma separators, 2 decimals
 
       - title: "Success Rate"
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         position: {x: 12, y: 0}
         lens:
           type: metric
@@ -375,7 +375,7 @@ dashboards:
   - name: "Combined Formatting"
     panels:
       - title: "Bandwidth Usage"
-        size: {w: 12, h: 8}
+        size: {w: 12, h: 4}
         lens:
           type: metric
           data_view: "network-*"


### PR DESCRIPTION
Reduce metric panel heights across all dashboard examples and documentation to provide a more compact display. Previously panels used heights of 6 or 8 grid units, which was unnecessarily tall for single-value metric displays.

**Changes:**
- Update 35 dashboard YAML files (140 metric panels)
- Update dashboard-style-guide.md recommendation from 8 to 4 grid units
- Update metric.md documentation examples
- Update esql-views.md documentation examples

Closes #1096

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Dashboard panels resized across monitoring and observability dashboards with reduced vertical spacing for more compact and efficient layouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->