### PR TITLE
feat(examples): add IIS OTel receiver dashboard

### DIFF
--- a/packages/kb-dashboard-docs/content/examples/iis_otel/01-iis-overview.yaml
+++ b/packages/kb-dashboard-docs/content/examples/iis_otel/01-iis-overview.yaml
@@ -422,14 +422,14 @@ dashboards:
         esql:
           type: datatable
           query: |
-            FROM metrics-*
+            TS metrics-*
             | WHERE data_stream.dataset == "iisreceiver.otel"
             | WHERE resource.attributes.iis.site IS NOT NULL
             | STATS
-                connections = ROUND(MAX(iis.connection.active), 0),
-                queue = ROUND(MAX(iis.request.queue.count), 0),
-                threads = ROUND(MAX(iis.thread.active), 0),
-                uptime_sec = MAX(iis.uptime)
+                connections = ROUND(MAX(LAST_OVER_TIME(iis.connection.active)), 0),
+                queue = ROUND(MAX(LAST_OVER_TIME(iis.request.queue.count)), 0),
+                threads = ROUND(MAX(LAST_OVER_TIME(iis.thread.active)), 0),
+                uptime_sec = MAX(LAST_OVER_TIME(iis.uptime))
               BY site = resource.attributes.iis.site
             | EVAL uptime_hrs = ROUND(uptime_sec / 3600, 1)
             | KEEP site, connections, queue, threads, uptime_hrs

--- a/packages/kb-dashboard-docs/content/examples/iis_otel/README.md
+++ b/packages/kb-dashboard-docs/content/examples/iis_otel/README.md
@@ -57,19 +57,19 @@ All metrics are enabled by default.
 
 | Metric | Type | Unit | Description | Attributes |
 |--------|------|------|-------------|------------|
-| `iis.application_pool.state` | Gauge | `{state}` | Application pool state (1-7: Uninitialized to Delete Pending) | — |
-| `iis.application_pool.uptime` | Gauge | `{ms}` | Application pool uptime since last restart | — |
-| `iis.connection.active` | Sum | `{connections}` | Number of active connections | — |
-| `iis.connection.anonymous` | Sum | `{connections}` | Connections established anonymously | — |
-| `iis.connection.attempt.count` | Sum | `{attempts}` | Total connection attempts | — |
+| `iis.application_pool.state` | Gauge | `1` | Application pool state (1-7: Uninitialized to Delete Pending) | — |
+| `iis.application_pool.uptime` | Gauge | `s` | Application pool uptime since last restart | — |
+| `iis.connection.active` | Sum | `{connection}` | Number of active connections | — |
+| `iis.connection.anonymous` | Sum | `{connection}` | Connections established anonymously | — |
+| `iis.connection.attempt.count` | Sum | `{attempt}` | Total connection attempts | — |
 | `iis.network.blocked` | Sum | `By` | Bytes blocked due to bandwidth throttling | — |
-| `iis.network.file.count` | Sum | `{files}` | Number of transmitted files | `direction` |
+| `iis.network.file.count` | Sum | `{file}` | Number of transmitted files | `direction` |
 | `iis.network.io` | Sum | `By` | Total bytes sent and received | `direction` |
-| `iis.request.count` | Sum | `{requests}` | Total requests by HTTP method | `request` |
-| `iis.request.queue.age.max` | Gauge | `ms` | Age of oldest request in the queue | — |
-| `iis.request.queue.count` | Sum | `{requests}` | Current number of requests in the queue | — |
-| `iis.request.rejected` | Sum | `{requests}` | Total number of rejected requests | — |
-| `iis.thread.active` | Sum | `{threads}` | Current number of active threads | — |
+| `iis.request.count` | Sum | `{request}` | Total requests by HTTP method | `request` |
+| `iis.request.queue.age.max` | Gauge | `s` | Age of oldest request in the queue | — |
+| `iis.request.queue.count` | Sum | `{request}` | Current number of requests in the queue | — |
+| `iis.request.rejected` | Sum | `{request}` | Total number of rejected requests | — |
+| `iis.thread.active` | Sum | `{thread}` | Current number of active threads | — |
 | `iis.uptime` | Gauge | `s` | Server uptime in seconds | — |
 
 ### Metric Attributes


### PR DESCRIPTION
Closes #741

Create a comprehensive Kibana Lens dashboard for monitoring Microsoft IIS using the OpenTelemetry Collector's iisreceiver.

## Summary
- Visualizes all 14 IIS receiver metrics
- Panels grouped logically: Overview, Application Pool, Requests, Connections, Network, Performance
- Includes controls for filtering by application pool and site
- Uses ES|QL with TS command for time-series optimization

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenTelemetry IIS dashboard with panels for uptime, connections, request queues, application pool states, request rates, network I/O, thread performance, and site summaries.
* **Documentation**
  * Added a README covering dashboard overview, prerequisites, data/metrics reference, attribute mappings, application pool state values, and collector configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->