### PR TITLE
Mention linting in guides

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -65,6 +65,7 @@ Run these from the **repository root**:
 | `make lint-markdown-check` | Check markdown linting (repo-wide) |
 | `make lint-yaml-check` | Check YAML linting (repo-wide) |
 | `make docs ci` | Check documentation (markdown lint + link verification) |
+| `kb-dashboard-lint check --input-file <file>` | Check dashboard YAML for best practices |
 
 **Troubleshooting CI failures:** Run `make all ci` + lint commands locally to reproduce CI checks.
 

--- a/packages/kb-dashboard-docs/content/CLI.md
+++ b/packages/kb-dashboard-docs/content/CLI.md
@@ -298,3 +298,72 @@ If objects fail to upload:
 - Check the Kibana logs for detailed error messages
 - Verify the NDJSON format is valid
 - Use `--no-overwrite` if you want to preserve existing objects
+
+---
+
+## Dashboard Linter CLI
+
+The `kb-dashboard-lint` CLI tool checks YAML dashboard configurations for best practices and common issues.
+
+### Basic Usage
+
+Check a single dashboard file:
+
+```bash
+kb-dashboard-lint check --input-file ./dashboards/example.yaml
+```
+
+Check all dashboards in a directory:
+
+```bash
+kb-dashboard-lint check --input-dir ./dashboards
+```
+
+### Severity Levels
+
+The linter reports issues at three severity levels:
+
+| Level | Description |
+| ----- | ----------- |
+| **error** | Critical issues that should be fixed |
+| **warning** | Problems that may affect usability |
+| **info** | Suggestions for improvement |
+
+By default, the linter exits with code 0 for info-only results. Use `--severity-threshold` to fail on warnings:
+
+```bash
+kb-dashboard-lint check --input-file dashboard.yaml --severity-threshold warning
+```
+
+### List Available Rules
+
+See all lint rules and their descriptions:
+
+```bash
+kb-dashboard-lint list-rules
+```
+
+### Configuration
+
+Create a `.dashboard-lint.yaml` file to customize rule behavior:
+
+```bash
+kb-dashboard-lint check --config .dashboard-lint.yaml
+```
+
+### Output Formats
+
+Get machine-readable output for CI integration:
+
+```bash
+kb-dashboard-lint check --input-dir ./dashboards --format json
+```
+
+### Linter Command Reference
+
+::: mkdocs-click
+    :module: dashboard_lint.cli
+    :command: cli
+    :prog_name: kb-dashboard-lint
+    :depth: 2
+    :style: table


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Document dashboard linting by adding `kb-dashboard-lint check --input-file <file>` to [DEVELOPING.md](https://github.com/strawgate/kb-yaml-to-lens/pull/1153/files#diff-8822179a8da757fde968cf80a9162e1c1d6f8cc170509cfbdea10be03b7e7d20) and a new CLI guide in [packages/kb-dashboard-docs/content/CLI.md](https://github.com/strawgate/kb-yaml-to-lens/pull/1153/files#diff-90aeef8fcf44eed9fdf9c26d2be74a004d70ec02af698e3283122793549ba799)
Add repo command docs for `kb-dashboard-lint check --input-file <file>` and append a CLI section covering usage for files and directories, severity levels (`error`, `warning`, `info`) with `--severity-threshold`, rule listing via `kb-dashboard-lint list-rules`, config via `--config` (.dashboard-lint.yaml), and JSON output with `--format json`, rendered via `mkdocs-click` from `dashboard_lint.cli` with program `kb-dashboard-lint`.

#### 📍Where to Start
Start with the new CLI docs in [packages/kb-dashboard-docs/content/CLI.md](https://github.com/strawgate/kb-yaml-to-lens/pull/1153/files#diff-90aeef8fcf44eed9fdf9c26d2be74a004d70ec02af698e3283122793549ba799), then verify the repo command addition in [DEVELOPING.md](https://github.com/strawgate/kb-yaml-to-lens/pull/1153/files#diff-8822179a8da757fde968cf80a9162e1c1d6f8cc170509cfbdea10be03b7e7d20).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 71ae1cf.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->