### PR TITLE
docs: update CLI instructions to use uvx for zero-setup installation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,8 @@
 # Developing
 
-This guide covers development workflows for the kb-yaml-to-lens project.
+This guide covers development workflows for **contributors** to the kb-yaml-to-lens project.
+
+> **End users:** You don't need to clone this repository to use the CLI. Simply run `uvx kb-dashboard-cli compile --help` to get started. See the [CLI Documentation](https://strawgate.github.io/kb-yaml-to-lens/CLI) for usage details.
 
 ## Project Structure
 

--- a/packages/kb-dashboard-cli/README.md
+++ b/packages/kb-dashboard-cli/README.md
@@ -23,8 +23,9 @@ It converts human-friendly YAML dashboard definitions into Kibana NDJSON format:
 - No Python installation required - bundled binary included!
 
 **For CLI (Automation/CI):**
-- Python 3.12+
-- [uv](https://github.com/astral-sh/uv) (recommended for dependency management)
+
+- [uv](https://github.com/astral-sh/uv) for running via `uvx` (recommended - no Python setup required)
+- Or Python 3.12+ with pip/uv for traditional installation
 
 ## Quick Start
 
@@ -76,20 +77,20 @@ If commands don't appear, restart VS Code and check the Output panel (View → O
 
 **Best for:** Scripting, CI/CD pipelines, batch processing, programmatic usage
 
-The CLI provides three installation methods:
+The CLI provides multiple installation methods:
 
 <details>
 <summary><b>Click to expand CLI installation options</b></summary>
 
-#### Using uv (Recommended for Development)
+#### Using uvx (Recommended)
 
-This project uses [uv](https://github.com/astral-sh/uv) for fast, reliable Python package management.
-
-**For basic usage (compiling dashboards):**
+Run the CLI directly without cloning or installing anything (requires [uv](https://github.com/astral-sh/uv)):
 
 ```bash
-uv sync
+uvx kb-dashboard-cli compile --help
 ```
+
+This downloads and runs the published package automatically. No Python environment setup required!
 
 #### Using Docker
 
@@ -114,6 +115,18 @@ Download a platform-specific binary from the [releases page](https://github.com/
 
 No Python installation required!
 
+#### From Source (For Development)
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/strawgate/kb-yaml-to-lens
+cd kb-yaml-to-lens
+make cli install
+```
+
+See [DEVELOPING.md](../../DEVELOPING.md) for full development setup.
+
 </details>
 
 #### Compile Your First Dashboard (CLI)
@@ -136,7 +149,7 @@ dashboards:
 
 2. Compile to NDJSON:
 
-If using uv: `uv run kb-dashboard compile --input-dir inputs --output-dir output`
+If using uvx: `uvx kb-dashboard-cli compile --input-dir inputs --output-dir output`
 
 If using Docker:
 ```bash

--- a/packages/kb-dashboard-docs/content/CLI.md
+++ b/packages/kb-dashboard-docs/content/CLI.md
@@ -4,10 +4,10 @@ The `kb-dashboard` CLI tool allows you to compile YAML dashboard configurations 
 
 ## Prerequisites
 
-- **Python 3.12+** - Required for CLI usage
-- **[uv](https://github.com/astral-sh/uv)** (recommended) or pip for dependency management
+- **[uv](https://github.com/astral-sh/uv)** (recommended) - Enables running the CLI via `uvx` with zero setup
+- Or **Python 3.12+** with pip for traditional installation
 
-**Note:** The VS Code Extension does not require Python - it includes a bundled binary. See [VS Code Extension Documentation](vscode-extension.md) for zero-configuration setup.
+**Note:** When using `uvx`, Python and all dependencies are handled automatically. The VS Code Extension does not require Python either - it includes a bundled binary. See [VS Code Extension Documentation](vscode-extension.md) for zero-configuration setup.
 
 ## When to Use the CLI
 
@@ -33,11 +33,27 @@ The `kb-dashboard` CLI tool allows you to compile YAML dashboard configurations 
 
 ## Installation
 
-After installing the project dependencies, the CLI will be available:
+### Using uvx (Recommended)
+
+Run the CLI directly without cloning or installing anything:
 
 ```bash
-uv sync
+uvx kb-dashboard-cli compile --help
 ```
+
+This downloads and runs the published package automatically. No Python environment setup required!
+
+### Development Installation
+
+For contributors or development workflows, clone the repository:
+
+```bash
+git clone https://github.com/strawgate/kb-yaml-to-lens
+cd kb-yaml-to-lens
+make cli install
+```
+
+See [DEVELOPING.md](https://github.com/strawgate/kb-yaml-to-lens/blob/main/DEVELOPING.md) for full development setup.
 
 ## Basic Usage
 
@@ -46,7 +62,7 @@ uv sync
 Compile YAML dashboards to NDJSON format:
 
 ```bash
-kb-dashboard compile
+uvx kb-dashboard-cli compile
 ```
 
 This will:
@@ -62,7 +78,7 @@ This will:
 Compile a specific YAML file without scanning a directory:
 
 ```bash
-kb-dashboard compile --input-file ./dashboards/example.yaml
+uvx kb-dashboard-cli compile --input-file ./dashboards/example.yaml
 ```
 
 When `--input-file` is provided, `--input-dir` is ignored.
@@ -72,7 +88,7 @@ When `--input-file` is provided, `--input-dir` is ignored.
 For workflows that require individual JSON files per dashboard (e.g., Fleet integration):
 
 ```bash
-kb-dashboard compile --format json --output-dir ./output
+uvx kb-dashboard-cli compile --format json --output-dir ./output
 ```
 
 This will:
@@ -85,7 +101,7 @@ This will:
 Use the `--exit-non-zero-on-change` flag to detect when YAML and JSON files are out of sync in CI pipelines:
 
 ```bash
-kb-dashboard compile --format json --output-dir ./dashboards --exit-non-zero-on-change
+uvx kb-dashboard-cli compile --format json --output-dir ./dashboards --exit-non-zero-on-change
 if [ $? -ne 0 ]; then
     echo "Dashboard JSON files are out of sync with YAML sources"
     exit 1
@@ -99,7 +115,7 @@ When this flag is enabled, the exit code equals the number of files that changed
 Compile dashboards and upload them directly to Kibana:
 
 ```bash
-kb-dashboard compile --upload
+uvx kb-dashboard-cli compile --upload
 ```
 
 This will compile the dashboards and upload them to a local Kibana instance.
@@ -109,7 +125,7 @@ This will compile the dashboards and upload them to a local Kibana instance.
 Generate a PNG screenshot of a dashboard:
 
 ```bash
-kb-dashboard screenshot --dashboard-id <id> --output <file.png>
+uvx kb-dashboard-cli screenshot --dashboard-id <id> --output <file.png>
 ```
 
 This will use Kibana's Reporting API to take a screenshot.
@@ -119,7 +135,7 @@ This will use Kibana's Reporting API to take a screenshot.
 Export a dashboard from Kibana and create a pre-filled GitHub issue:
 
 ```bash
-kb-dashboard export-for-issue --dashboard-id <id>
+uvx kb-dashboard-cli export-for-issue --dashboard-id <id>
 ```
 
 This will export the dashboard and open your browser with a pre-filled GitHub issue containing the dashboard JSON.
@@ -129,7 +145,7 @@ This will export the dashboard and open your browser with a pre-filled GitHub is
 Break down a Kibana dashboard JSON into components for easier LLM-based conversion:
 
 ```bash
-kb-dashboard disassemble dashboard.ndjson -o output_dir
+uvx kb-dashboard-cli disassemble dashboard.ndjson -o output_dir
 ```
 
 This will extract the dashboard into separate files:
@@ -161,7 +177,7 @@ export KIBANA_API_KEY=your-api-key-here
 Then simply run:
 
 ```bash
-kb-dashboard compile --upload
+uvx kb-dashboard-cli compile --upload
 ```
 
 ### Command-Line Options
@@ -169,7 +185,7 @@ kb-dashboard compile --upload
 All options can also be specified on the command line:
 
 ```bash
-kb-dashboard compile \
+uvx kb-dashboard-cli compile \
   --upload \
   --kibana-url http://localhost:5601 \
   --kibana-username elastic \
@@ -179,14 +195,14 @@ kb-dashboard compile \
 To upload to a specific Kibana space:
 
 ```bash
-kb-dashboard compile --upload --kibana-space-id production
+uvx kb-dashboard-cli compile --upload --kibana-space-id production
 ```
 
 Or with environment variables:
 
 ```bash
 export KIBANA_SPACE_ID=staging
-kb-dashboard compile --upload
+uvx kb-dashboard-cli compile --upload
 ```
 
 ## Command Reference
@@ -200,9 +216,9 @@ The following commands are available in the `kb-dashboard` CLI. For detailed inf
     :depth: 2
     :style: table
 
-## Makefile Shortcuts
+## Makefile Shortcuts (Development)
 
-The project includes convenient Makefile targets (run from repository root):
+For contributors working from a cloned repository, the project includes convenient Makefile targets:
 
 ```bash
 # Compile only
@@ -212,19 +228,7 @@ make cli compile
 make cli upload
 ```
 
-Or use the CLI directly from anywhere with uv:
-
-```bash
-cd packages/kb-dashboard-cli && uv run kb-dashboard compile
-cd packages/kb-dashboard-cli && uv run kb-dashboard compile --upload
-```
-
-Or using the passthrough pattern from repository root:
-
-```bash
-make cli compile
-make cli upload
-```
+See [DEVELOPING.md](https://github.com/strawgate/kb-yaml-to-lens/blob/main/DEVELOPING.md) for the full development workflow.
 
 ## Authentication
 
@@ -235,7 +239,7 @@ The CLI supports two authentication methods:
 Use username and password:
 
 ```bash
-kb-dashboard compile \
+uvx kb-dashboard-cli compile \
   --upload \
   --kibana-username elastic \
   --kibana-password changeme
@@ -246,7 +250,7 @@ Or via environment variables:
 ```bash
 export KIBANA_USERNAME=elastic
 export KIBANA_PASSWORD=changeme
-kb-dashboard compile --upload
+uvx kb-dashboard-cli compile --upload
 ```
 
 ### API Key Authentication
@@ -254,7 +258,7 @@ kb-dashboard compile --upload
 Use a Kibana API key:
 
 ```bash
-kb-dashboard compile \
+uvx kb-dashboard-cli compile \
   --upload \
   --kibana-api-key "your-base64-encoded-key"
 ```
@@ -263,7 +267,7 @@ Or via environment variable:
 
 ```bash
 export KIBANA_API_KEY="your-base64-encoded-key"
-kb-dashboard compile --upload
+uvx kb-dashboard-cli compile --upload
 ```
 
 To create an API key in Kibana:
@@ -310,13 +314,13 @@ The `kb-dashboard-lint` CLI tool checks YAML dashboard configurations for best p
 Check a single dashboard file:
 
 ```bash
-kb-dashboard-lint check --input-file ./dashboards/example.yaml
+uvx kb-dashboard-lint check --input-file ./dashboards/example.yaml
 ```
 
 Check all dashboards in a directory:
 
 ```bash
-kb-dashboard-lint check --input-dir ./dashboards
+uvx kb-dashboard-lint check --input-dir ./dashboards
 ```
 
 ### Severity Levels
@@ -332,7 +336,7 @@ The linter reports issues at three severity levels:
 By default, the linter exits with code 0 for info-only results. Use `--severity-threshold` to fail on warnings:
 
 ```bash
-kb-dashboard-lint check --input-file dashboard.yaml --severity-threshold warning
+uvx kb-dashboard-lint check --input-file dashboard.yaml --severity-threshold warning
 ```
 
 ### List Available Rules
@@ -340,7 +344,7 @@ kb-dashboard-lint check --input-file dashboard.yaml --severity-threshold warning
 See all lint rules and their descriptions:
 
 ```bash
-kb-dashboard-lint list-rules
+uvx kb-dashboard-lint list-rules
 ```
 
 ### Configuration
@@ -348,7 +352,7 @@ kb-dashboard-lint list-rules
 Create a `.dashboard-lint.yaml` file to customize rule behavior:
 
 ```bash
-kb-dashboard-lint check --config .dashboard-lint.yaml
+uvx kb-dashboard-lint check --config .dashboard-lint.yaml
 ```
 
 ### Output Formats
@@ -356,7 +360,7 @@ kb-dashboard-lint check --config .dashboard-lint.yaml
 Get machine-readable output for CI integration:
 
 ```bash
-kb-dashboard-lint check --input-dir ./dashboards --format json
+uvx kb-dashboard-lint check --input-dir ./dashboards --format json
 ```
 
 ### Linter Command Reference

--- a/packages/kb-dashboard-docs/content/examples/index.md
+++ b/packages/kb-dashboard-docs/content/examples/index.md
@@ -5,18 +5,24 @@ This section provides real-world YAML dashboard examples demonstrating various f
 ## How to Use These Examples
 
 1. **Browse:** Click on any example bundle below to view its README with complete documentation
-2. **Copy:** Each bundle contains YAML files you can copy to your `inputs/` directory
-3. **Compile:** Run the compiler:
+2. **Copy:** Each bundle contains YAML files you can copy to your local directory
+3. **Compile:** Run the compiler using uvx (no clone required):
 
    ```bash
-   kb-dashboard compile
+   uvx kb-dashboard-cli compile --input-file my-dashboard.yaml
    ```
 
 4. **Upload (Optional):** To upload directly to Kibana:
 
    ```bash
-   kb-dashboard compile --upload
+   uvx kb-dashboard-cli compile --input-file my-dashboard.yaml --upload
    ```
+
+**For contributors:** If you've cloned the repository, you can compile examples from the repo:
+
+```bash
+uvx kb-dashboard-cli compile --input-dir packages/kb-dashboard-docs/content/examples --output-dir output
+```
 
 ## Standalone Examples
 
@@ -168,7 +174,7 @@ All example files are located in the `packages/kb-dashboard-docs/content/example
 
 1. **View README:** Click the bundle link to see complete setup instructions and dashboard descriptions
 2. **Clone locally:** Download the repository to experiment with examples
-3. **Compile examples:** Run `kb-dashboard compile --input-dir packages/kb-dashboard-docs/content/examples --output-dir output` to generate NDJSON files
+3. **Compile examples:** Run `uvx kb-dashboard-cli compile --input-dir packages/kb-dashboard-docs/content/examples --output-dir output` to generate NDJSON files
 
 ## Using Examples as Templates
 

--- a/packages/kb-dashboard-docs/content/index.md
+++ b/packages/kb-dashboard-docs/content/index.md
@@ -59,13 +59,12 @@ hand-crafting complex JSON.
 
 **Best for:** CI/CD pipelines, batch processing, programmatic usage
 
-**Requirements:** Python 3.12+
+**Requirements:** [uv](https://github.com/astral-sh/uv) (recommended) or Python 3.12+
 
-**Installation** using [uv](https://github.com/astral-sh/uv):
+**Installation:** No clone or setup required! Run directly with uvx:
 
 ```bash
-# From repository root
-make cli install
+uvx kb-dashboard-cli compile --help
 ```
 
 **Your First Dashboard:**
@@ -87,14 +86,13 @@ make cli install
 2. Compile:
 
    ```bash
-   # From repository root
-   make cli compile
+   uvx kb-dashboard-cli compile --input-file inputs/my-dashboard.yaml
    ```
 
 3. Upload to Kibana:
 
    ```bash
-   uv run kb-dashboard compile --upload --kibana-url http://localhost:5601
+   uvx kb-dashboard-cli compile --input-file inputs/my-dashboard.yaml --upload --kibana-url http://localhost:5601
    ```
 
 **Full guide:** [CLI Documentation](CLI.md)


### PR DESCRIPTION
## Summary
- Add uvx as the recommended installation method in CLI documentation
- Update all command examples to use `uvx kb-dashboard-cli` pattern
- Preserve development installation instructions for contributors

Fixes #1167

🤖 Generated with [Claude Code](https://claude.ai/code)