### PR TITLE
docs: clarify agent documentation scope in CODERABBIT.md

### DIFF
--- a/CODERABBIT.md
+++ b/CODERABBIT.md
@@ -43,6 +43,7 @@ See component-specific CODERABBIT.md files for detailed review instructions:
 1. Style choices that match existing patterns
 2. Intentional deviations documented with pragmas
 3. Test file relaxations (asserts, magic numbers)
+4. Missing agent documentation in general markdown files - agent behavior documentation is only required in `AGENTS.md`, `CLAUDE.md`, and `CODERABBIT.md` files
 
 ---
 


### PR DESCRIPTION
Add explicit instruction that agent behavior documentation is only required in AGENTS.md, CLAUDE.md, and CODERABBIT.md files, not in general markdown documentation.

Closes #1180

Generated with [Claude Code](https://claude.ai/code)