### PR TITLE
feat(core): add collapsible dashboard section support

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/__init__.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/__init__.py
@@ -1,5 +1,5 @@
-"""Module for Dashboards objects and compilation."""
+"""Module for Dashboard objects and compilation."""
 
-from .config import Dashboard
+from .config import Dashboard, DashboardSection
 
-__all__ = ['Dashboard']
+__all__ = ['Dashboard', 'DashboardSection']

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/compile.py
@@ -1,11 +1,20 @@
 """Compile a Dashboard into its Kibana view model representation."""
 
+from collections.abc import Sequence
+
 from kb_dashboard_core.controls.compile import compile_control_group
-from kb_dashboard_core.dashboard.config import Dashboard, DashboardSettings
-from kb_dashboard_core.dashboard.view import KbnDashboard, KbnDashboardAttributes, KbnDashboardOptions
+from kb_dashboard_core.dashboard.config import Dashboard, DashboardSection, DashboardSettings
+from kb_dashboard_core.dashboard.view import (
+    KbnDashboard,
+    KbnDashboardAttributes,
+    KbnDashboardOptions,
+    KbnDashboardSection,
+    KbnDashboardSectionGridData,
+)
 from kb_dashboard_core.filters.compile import compile_filters
 from kb_dashboard_core.panels.compile import compile_dashboard_panels
-from kb_dashboard_core.panels.view import KbnSavedObjectMeta, KbnSearchSourceJSON
+from kb_dashboard_core.panels.types import PanelTypes
+from kb_dashboard_core.panels.view import KbnBasePanel, KbnSavedObjectMeta, KbnSearchSourceJSON
 from kb_dashboard_core.queries.compile import compile_nonesql_query
 from kb_dashboard_core.queries.view import KbnQuery
 from kb_dashboard_core.shared.config import stable_id_generator
@@ -37,6 +46,139 @@ def compile_dashboard_options(settings: DashboardSettings) -> KbnDashboardOption
     )
 
 
+def _panel_display_title(panel: PanelTypes, idx: int) -> str:
+    return panel.title if len(panel.title) > 0 else f'Panel #{idx + 1}'
+
+
+def _validate_panel_section_usage_without_sections(source_panels: Sequence[PanelTypes]) -> None:
+    for idx, panel in enumerate(source_panels):
+        if panel.section is not None:
+            msg = (
+                f'Panel "{_panel_display_title(panel, idx)}" references section "{panel.section}", '
+                'but dashboard.sections is empty.'
+            )
+            raise ValueError(msg)
+
+
+def _build_section_entries(section_configs: Sequence[DashboardSection]) -> tuple[list[tuple[DashboardSection, str]], dict[str, str]]:
+    section_entries: list[tuple[DashboardSection, str]] = []
+    title_to_uid: dict[str, str] = {}
+    explicit_id_to_uid: dict[str, str] = {}
+    seen_compiled_uids: set[str] = set()
+
+    for section in section_configs:
+        section_uid = section.id or stable_id_generator(['section', section.title])
+
+        if section_uid in seen_compiled_uids:
+            msg = f'Duplicate compiled section id "{section_uid}". Section ids must be unique.'
+            raise ValueError(msg)
+        seen_compiled_uids.add(section_uid)
+
+        if section.title in title_to_uid:
+            msg = f'Duplicate section title "{section.title}". Section titles must be unique.'
+            raise ValueError(msg)
+        title_to_uid[section.title] = section_uid
+
+        if section.id is not None:
+            if section.id in explicit_id_to_uid:
+                msg = f'Duplicate section id "{section.id}". Section ids must be unique.'
+                raise ValueError(msg)
+            if section.id in title_to_uid and title_to_uid[section.id] != section_uid:
+                msg = (
+                    f'Section id "{section.id}" conflicts with another section title. '
+                    'Use unique ids/titles for unambiguous panel.section references.'
+                )
+                raise ValueError(msg)
+            explicit_id_to_uid[section.id] = section_uid
+
+        section_entries.append((section, section_uid))
+
+    return section_entries, {**title_to_uid, **explicit_id_to_uid}
+
+
+def _assign_sections_to_panels(
+    source_panels: Sequence[PanelTypes],
+    compiled_panels: Sequence[KbnBasePanel],
+    section_lookup: dict[str, str],
+    section_entries: Sequence[tuple[DashboardSection, str]],
+) -> tuple[list[KbnBasePanel], dict[str, list[int]]]:
+    section_panel_ys: dict[str, list[int]] = {section_uid: [] for _, section_uid in section_entries}
+    resolved_panels: list[KbnBasePanel] = []
+
+    for idx, (source_panel, compiled_panel) in enumerate(zip(source_panels, compiled_panels, strict=True)):
+        if source_panel.section is None:
+            resolved_panels.append(compiled_panel)
+            continue
+
+        section_uid = section_lookup.get(source_panel.section)
+        if section_uid is None:
+            msg = (
+                f'Panel "{_panel_display_title(source_panel, idx)}" references unknown section "{source_panel.section}". '
+                'Add this section to dashboard.sections.'
+            )
+            raise ValueError(msg)
+
+        section_panel_ys[section_uid].append(compiled_panel.gridData.y)
+        updated_grid_data = compiled_panel.gridData.model_copy(update={'sectionId': section_uid})
+        resolved_panels.append(compiled_panel.model_copy(update={'gridData': updated_grid_data}))
+
+    return resolved_panels, section_panel_ys
+
+
+def _compile_sections(
+    section_entries: Sequence[tuple[DashboardSection, str]],
+    section_panel_ys: dict[str, list[int]],
+) -> list[KbnDashboardSection]:
+    compiled_sections: list[KbnDashboardSection] = []
+    next_auto_y = 0
+
+    for section, section_uid in section_entries:
+        section_y_values = section_panel_ys[section_uid]
+        section_y = section.y if section.y is not None else (min(section_y_values) if len(section_y_values) > 0 else next_auto_y)
+        next_auto_y = max(next_auto_y, section_y + 1)
+        compiled_sections.append(
+            KbnDashboardSection(
+                title=section.title,
+                collapsed=section.collapsed,
+                gridData=KbnDashboardSectionGridData(y=section_y, i=section_uid),
+            )
+        )
+
+    return compiled_sections
+
+
+@log_compile
+def _resolve_sections(
+    section_configs: Sequence[DashboardSection],
+    source_panels: Sequence[PanelTypes],
+    compiled_panels: Sequence[KbnBasePanel],
+) -> tuple[list[KbnBasePanel], list[KbnDashboardSection] | None]:
+    """Resolve section references for panels and compile dashboard sections."""
+    if len(source_panels) != len(compiled_panels):
+        msg = (
+            f'Internal error: source and compiled panel counts differ '
+            f'({len(source_panels)} != {len(compiled_panels)}).'
+        )
+        raise ValueError(msg)
+
+    if len(section_configs) == 0:
+        _validate_panel_section_usage_without_sections(source_panels)
+        return list(compiled_panels), None
+
+    section_entries, section_lookup = _build_section_entries(section_configs)
+    resolved_panels, section_panel_ys = _assign_sections_to_panels(
+        source_panels=source_panels,
+        compiled_panels=compiled_panels,
+        section_lookup=section_lookup,
+        section_entries=section_entries,
+    )
+    compiled_sections = _compile_sections(
+        section_entries=section_entries,
+        section_panel_ys=section_panel_ys,
+    )
+    return resolved_panels, compiled_sections
+
+
 @log_compile
 def compile_dashboard_attributes(dashboard: Dashboard) -> tuple[list[KbnReference], KbnDashboardAttributes]:
     """Compile the attributes of a Dashboard object into its Kibana view model representation.
@@ -51,6 +193,11 @@ def compile_dashboard_attributes(dashboard: Dashboard) -> tuple[list[KbnReferenc
     panel_references, panels = compile_dashboard_panels(
         dashboard.panels,
         layout_algorithm=dashboard.settings.layout_algorithm,
+    )
+    panels, sections = _resolve_sections(
+        section_configs=dashboard.sections,
+        source_panels=dashboard.panels,
+        compiled_panels=panels,
     )
 
     control_group_input, control_references = compile_control_group(
@@ -69,6 +216,7 @@ def compile_dashboard_attributes(dashboard: Dashboard) -> tuple[list[KbnReferenc
         title=dashboard.name,
         description=dashboard.description or '',
         panelsJSON=panels,
+        sections=sections,
         kibanaSavedObjectMeta=KbnSavedObjectMeta(
             searchSourceJSON=KbnSearchSourceJSON(
                 filter=compile_filters(filters=dashboard.filters),

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/config.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/config.py
@@ -1,6 +1,6 @@
 from typing import Self
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from kb_dashboard_core.controls import ControlTypes
 from kb_dashboard_core.controls.config import ControlSettings
@@ -50,6 +50,22 @@ class DashboardSettings(BaseCfgModel):
     """The auto-layout algorithm to use for positioning panels without explicit coordinates. Defaults to 'up-left'."""
 
 
+class DashboardSection(BaseCfgModel):
+    """Collapsible dashboard section metadata."""
+
+    id: str | None = Field(default=None)
+    """Optional stable section identifier. If omitted, a stable ID is generated from the title."""
+
+    title: str = Field(...)
+    """Section title shown in Kibana."""
+
+    collapsed: bool | None = Field(default=None)
+    """Whether the section is collapsed by default."""
+
+    y: int | None = Field(default=None, ge=0, validation_alias=AliasChoices('y', 'from_top'))
+    """Optional section header Y coordinate. If omitted, derived from the section's panels."""
+
+
 class Dashboard(BaseCfgModel):
     """A dashboard with filters, controls, panels and more."""
 
@@ -75,6 +91,9 @@ class Dashboard(BaseCfgModel):
 
     controls: list[ControlTypes] = Field(default_factory=list)
     """A list of Controls for the dashboard."""
+
+    sections: list[DashboardSection] = Field(default_factory=list)
+    """Collapsible sections available to dashboard panels."""
 
     panels: list[PanelTypes] = Field(default_factory=list)
     """A list of Panels defining the content and layout of the dashboard."""
@@ -107,6 +126,20 @@ class Dashboard(BaseCfgModel):
 
         """
         self.controls.append(control)
+
+        return self
+
+    def add_section(self, section: DashboardSection) -> Self:
+        """Add a collapsible section to the dashboard.
+
+        Args:
+            section: The section object to add.
+
+        Returns:
+            Self: The current instance of the Dashboard for method chaining.
+
+        """
+        self.sections.append(section)
 
         return self
 

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/dashboard/view.py
@@ -23,10 +23,26 @@ class KbnDashboardOptions(BaseModel):
     """Whether to hide the titles in the panel headers."""
 
 
+class KbnDashboardSectionGridData(BaseVwModel):
+    """Grid metadata for a collapsible dashboard section."""
+
+    y: int
+    i: str
+
+
+class KbnDashboardSection(BaseVwModel):
+    """Represents a collapsible dashboard section in Kibana saved object attributes."""
+
+    title: str
+    collapsed: Annotated[bool | None, OmitIfNone()] = None
+    gridData: KbnDashboardSectionGridData
+
+
 class KbnDashboardAttributes(BaseVwModel):
     title: str
     description: str
     panelsJSON: list[KbnBasePanel]
+    sections: Annotated[list[KbnDashboardSection] | None, OmitIfNone()] = Field(default=None)
     optionsJSON: KbnDashboardOptions
     kibanaSavedObjectMeta: KbnSavedObjectMeta
     timeRestore: bool

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/base.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/base.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from kb_dashboard_core.panels.config import Position, Size
 from kb_dashboard_core.panels.drilldowns.config import DrilldownTypes
@@ -33,6 +33,9 @@ class BasePanel(BaseCfgModel):
 
     position: Position = Field(default_factory=Position)
     """Defines the panel's position on the dashboard grid. If not specified, position will be auto-calculated."""
+
+    section: str | None = Field(default=None, validation_alias=AliasChoices('section', 'section_id'))
+    """Optional collapsible section identifier (or title) this panel belongs to."""
 
     drilldowns: list[DrilldownTypes] | None = Field(default=None)
     """Optional list of drilldowns to attach to this panel."""

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/view.py
@@ -26,6 +26,7 @@ class KbnGridData(BaseVwModel):
     w: int
     h: int
     i: str
+    sectionId: Annotated[str | None, OmitIfNone()] = None
 
 
 class KbnBasePanelEmbeddableConfig(BaseVwModel):

--- a/packages/kb-dashboard-core/tests/dashboards/test_sections.py
+++ b/packages/kb-dashboard-core/tests/dashboards/test_sections.py
@@ -1,0 +1,89 @@
+"""Tests for collapsible dashboard section compilation."""
+
+import pytest
+
+from kb_dashboard_core.dashboard.config import Dashboard
+from kb_dashboard_core.dashboard_compiler import render
+from kb_dashboard_core.shared.config import stable_id_generator
+from tests.conftest import de_json_kbn_dashboard
+
+
+def test_dashboard_sections_compile_with_panel_assignments() -> None:
+    """Panels assigned to sections compile to gridData.sectionId and attributes.sections."""
+    dashboard = Dashboard(
+        name='Sections Dashboard',
+        sections=[{'id': 'perf', 'title': 'Performance', 'collapsed': True}],
+        panels=[
+            {
+                'id': 'top',
+                'title': 'Top Level',
+                'position': {'x': 0, 'y': 0},
+                'size': {'w': 24, 'h': 6},
+                'markdown': {'content': '# Top'},
+            },
+            {
+                'id': 'inside-perf',
+                'title': 'CPU Usage',
+                'section': 'perf',
+                'position': {'x': 0, 'y': 6},
+                'size': {'w': 24, 'h': 6},
+                'markdown': {'content': '# CPU'},
+            },
+        ],
+    )
+
+    compiled = de_json_kbn_dashboard(render(dashboard=dashboard).model_dump(by_alias=True))
+    attributes = compiled['attributes']
+
+    assert attributes['sections'] == [{'title': 'Performance', 'collapsed': True, 'gridData': {'y': 6, 'i': 'perf'}}]
+
+    panels_by_id = {panel['panelIndex']: panel for panel in attributes['panelsJSON']}
+    assert panels_by_id['inside-perf']['gridData']['sectionId'] == 'perf'
+    assert 'sectionId' not in panels_by_id['top']['gridData']
+
+
+def test_section_reference_can_resolve_by_title_with_generated_id() -> None:
+    """Panel section references can target a section by title when id is omitted."""
+    dashboard = Dashboard(
+        name='Sections by Title Dashboard',
+        sections=[{'title': 'Latency'}],
+        panels=[
+            {
+                'id': 'latency-panel',
+                'title': 'Latency',
+                'section': 'Latency',
+                'position': {'x': 0, 'y': 7},
+                'size': {'w': 24, 'h': 6},
+                'markdown': {'content': '# Latency'},
+            }
+        ],
+    )
+
+    compiled = de_json_kbn_dashboard(render(dashboard=dashboard).model_dump(by_alias=True))
+    expected_section_id = stable_id_generator(['section', 'Latency'])
+
+    assert compiled['attributes']['sections'] == [
+        {'title': 'Latency', 'gridData': {'y': 7, 'i': expected_section_id}}
+    ]
+    assert compiled['attributes']['panelsJSON'][0]['gridData']['sectionId'] == expected_section_id
+
+
+def test_unknown_section_reference_raises_error() -> None:
+    """Compiling fails when a panel references a non-existent section."""
+    dashboard = Dashboard(
+        name='Invalid Section Reference',
+        sections=[{'id': 'known', 'title': 'Known'}],
+        panels=[
+            {
+                'id': 'panel-1',
+                'title': 'Panel',
+                'section': 'missing',
+                'position': {'x': 0, 'y': 0},
+                'size': {'w': 24, 'h': 6},
+                'markdown': {'content': '# Missing'},
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match='references unknown section'):
+        _ = render(dashboard=dashboard)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds collapsible section support to dashboards, allowing panels to be grouped under named sections that can be expanded or collapsed in Kibana.

## Changes

- Add `DashboardSection` config model with `id`, `title`, `collapsed`, and optional `y` fields
- Add `sections` field to `Dashboard` config model and `add_section()` builder method
- Add `section` field (also accepts `section_id` alias) to `BasePanel` config
- Add `KbnDashboardSection` and `KbnDashboardSectionGridData` view models to `dashboard/view.py`
- Add `sections` field to `KbnDashboardAttributes`
- Add `sectionId` to `KbnGridData` view model
- Compile-time resolution of panel-to-section assignments: validates references, derives section `y` positions from assigned panels, and detects duplicate or unknown section references
- Export `DashboardSection` from the `dashboard` package `__init__`
- Tests covering explicit IDs, title-resolved IDs, and invalid reference error handling

## Testing Instructions

### Test Sample Config

```yaml
# Example YAML that can be compiled to test this PR
name: Example Dashboard with Sections
sections:
  - id: performance
    title: Performance
    collapsed: true
panels:
  - title: Top Level Panel
    size: {w: 24, h: 6}
    position: {x: 0, y: 0}
    markdown:
      content: "# Overview"
  - title: CPU Usage
    section: performance
    size: {w: 24, h: 6}
    position: {x: 0, y: 6}
    markdown:
      content: "# CPU"
```

### Expected Outcome

The compiled NDJSON should include a `sections` array in `attributes`, and panels assigned to the section should have `gridData.sectionId` set to the section's compiled ID:

```json
{
  "attributes": {
    "sections": [{"title": "Performance", "collapsed": true, "gridData": {"y": 6, "i": "performance"}}],
    "panelsJSON": [
      {"gridData": {"x": 0, "y": 0, "w": 24, "h": 6, "i": "..."}},
      {"gridData": {"x": 0, "y": 6, "w": 24, "h": 6, "i": "...", "sectionId": "performance"}}
    ]
  }
}
```

Panels not assigned to any section have no `sectionId` in their `gridData`.

### How to Verify

```bash
# Example verification commands (run from repository root)
make all install
make core test
```

## Related Issues

Relates to #248

## Checklist

- [x] All static checks pass (`make all ci`)
- [x] I followed the [contributing guide](CONTRIBUTING.md)
- [x] Tests added/updated as needed
- [ ] Documentation updated (if API changed)
- [ ] Breaking changes documented with migration path
- [x] Self-review completed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible section support to dashboard compilation
> - Adds `DashboardSection` to [config.py](https://github.com/strawgate/kb-yaml-to-lens/pull/1188/files#diff-c4a6d4b5d5531da848d79aff1ae9298617718d12f57a3bf2d78ab737bf66ac48) with `id`, `title`, `collapsed`, and `y`/`from_top` fields; `Dashboard` gains a `sections` list and `add_section()` helper.
> - Adds `section` field to `BasePanel` so panels can reference a section by id or title.
> - Extends [compile.py](https://github.com/strawgate/kb-yaml-to-lens/pull/1188/files#diff-3fa4e074b53330d3e141c57899ccb8ba34f006f46382cd9568dd4cf559fe42ab) with a `_resolve_sections` phase that assigns `gridData.sectionId` to panels and produces a `sections` array on the compiled dashboard attributes.
> - Raises `ValueError` on duplicate section ids/titles, unknown section references, or panels that reference sections when none are defined.
> - Risk: existing dashboard compilations that set `panel.section` without defining `dashboard.sections` will now fail with `ValueError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 551c21d. 7 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced collapsible dashboard sections to organize and group related panels
  * Panels can now be assigned to specific sections with automatic positioning
  * Sections support custom titles and collapsed/expanded states for better dashboard organization
  * Section references are validated to ensure proper panel placement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->