### PR TITLE
fix(core): rewrite ES|QL static values into query-backed fields and add gauge palette support

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/compile.py
@@ -5,6 +5,7 @@ from kb_dashboard_core.filters.compile import compile_filters
 from kb_dashboard_core.filters.config import FilterTypes
 from kb_dashboard_core.panels.charts.config import (
     AllChartTypes,
+    ESQLChartTypes,
     ESQLPanel,
     LensAreaPanelConfig,
     LensBarPanelConfig,
@@ -14,7 +15,12 @@ from kb_dashboard_core.panels.charts.config import (
 )
 from kb_dashboard_core.panels.charts.datatable.compile import compile_esql_datatable_chart, compile_lens_datatable_chart
 from kb_dashboard_core.panels.charts.datatable.config import ESQLDatatableChart, LensDatatableChart
-from kb_dashboard_core.panels.charts.gauge.compile import compile_esql_gauge_chart, compile_lens_gauge_chart
+from kb_dashboard_core.panels.charts.esql.columns.config import ESQLMetric, ESQLMetricTypes, ESQLStaticValue
+from kb_dashboard_core.panels.charts.gauge.compile import (
+    compile_esql_gauge_chart,
+    compile_lens_gauge_chart,
+    prepare_esql_gauge_chart,
+)
 from kb_dashboard_core.panels.charts.gauge.config import ESQLGaugeChart, LensGaugeChart
 from kb_dashboard_core.panels.charts.heatmap.compile import compile_esql_heatmap_chart, compile_lens_heatmap_chart
 from kb_dashboard_core.panels.charts.heatmap.config import ESQLHeatmapChart, LensHeatmapChart
@@ -51,9 +57,11 @@ from kb_dashboard_core.panels.charts.xy.config import (
     LensLineChart,
     LensReferenceLineLayer,
 )
+from kb_dashboard_core.panels.charts.xy.metrics import ESQLXYMetricTypes, XYESQLMetric, XYESQLStaticValue
 from kb_dashboard_core.panels.charts.xy.view import KbnXYVisualizationState
 from kb_dashboard_core.panels.drilldowns import compile_drilldowns
 from kb_dashboard_core.queries.compile import compile_esql_query, compile_nonesql_query
+from kb_dashboard_core.queries.config import ESQLQuery
 from kb_dashboard_core.queries.types import LegacyQueryTypes
 from kb_dashboard_core.queries.view import KbnQuery
 from kb_dashboard_core.shared.view import KbnReference
@@ -93,6 +101,148 @@ def chart_type_to_kbn_type_lens(chart: AllChartTypes) -> KbnVisualizationTypeEnu
         case _:  # pyright: ignore[reportUnnecessaryComparison]
             msg = f'Unsupported Lens chart type: {type(chart)}'
             raise NotImplementedError(msg)  # pyright: ignore[reportUnreachable]
+
+
+def _format_esql_numeric(value: int | float) -> str:
+    """Format a numeric literal for ESQL ``EVAL`` expressions."""
+    return str(value) if isinstance(value, int) else repr(value)
+
+
+def _build_static_field_name(chart_type: str, role: str, column_id: str) -> str:
+    """Generate a deterministic synthetic field name for static ES|QL values."""
+    return f'__kb_{chart_type}_{role}_{column_id.replace("-", "_")}'
+
+
+def _rewrite_esql_metric_static_value(
+    metric: ESQLMetricTypes,
+    *,
+    chart_type: str,
+    role: str,
+    eval_assignments: list[str],
+) -> ESQLMetric:
+    """Rewrite ESQL static metric values to synthetic query-backed fields."""
+    if isinstance(metric, ESQLStaticValue):
+        field_name = _build_static_field_name(chart_type, role, metric.get_id())
+        eval_assignments.append(f'{field_name} = {_format_esql_numeric(metric.value)}')
+        return ESQLMetric(
+            id=metric.get_id(),
+            field=field_name,
+            label=metric.label if metric.label is not None else str(metric.value),
+        )
+    return metric
+
+
+def _rewrite_esql_xy_metric_static_value(
+    metric: ESQLXYMetricTypes,
+    *,
+    chart_type: str,
+    role: str,
+    eval_assignments: list[str],
+) -> ESQLXYMetricTypes:
+    """Rewrite XY ESQL static metric values while preserving axis/color appearance."""
+    if isinstance(metric, XYESQLStaticValue):
+        field_name = _build_static_field_name(chart_type, role, metric.get_id())
+        eval_assignments.append(f'{field_name} = {_format_esql_numeric(metric.value)}')
+        return XYESQLMetric(
+            id=metric.get_id(),
+            field=field_name,
+            label=metric.label if metric.label is not None else str(metric.value),
+            axis=metric.axis,
+            color=metric.color,
+        )
+    return metric
+
+
+def _prepare_esql_chart_static_values(
+    chart: ESQLChartTypes,
+    query: ESQLQuery,
+) -> tuple[ESQLChartTypes, ESQLQuery]:
+    """Rewrite static values in ES|QL chart configs into synthetic ``EVAL`` fields."""
+    if isinstance(chart, ESQLGaugeChart):
+        prepared_chart, prepared_query = prepare_esql_gauge_chart(chart, query=query)
+        return prepared_chart, prepared_query if prepared_query is not None else query
+
+    eval_assignments: list[str] = []
+    updates: dict[str, object] = {}
+
+    match chart:
+        case ESQLMetricChart():
+            updates['primary'] = _rewrite_esql_metric_static_value(
+                chart.primary,
+                chart_type=chart.type,
+                role='primary',
+                eval_assignments=eval_assignments,
+            )
+            if chart.secondary is not None:
+                updates['secondary'] = _rewrite_esql_metric_static_value(
+                    chart.secondary,
+                    chart_type=chart.type,
+                    role='secondary',
+                    eval_assignments=eval_assignments,
+                )
+            if chart.maximum is not None:
+                updates['maximum'] = _rewrite_esql_metric_static_value(
+                    chart.maximum,
+                    chart_type=chart.type,
+                    role='maximum',
+                    eval_assignments=eval_assignments,
+                )
+        case ESQLHeatmapChart():
+            updates['value'] = _rewrite_esql_metric_static_value(
+                chart.value,
+                chart_type=chart.type,
+                role='value',
+                eval_assignments=eval_assignments,
+            )
+        case ESQLPieChart():
+            updates['metrics'] = [
+                _rewrite_esql_metric_static_value(
+                    metric,
+                    chart_type=chart.type,
+                    role=f'metric_{index}',
+                    eval_assignments=eval_assignments,
+                )
+                for index, metric in enumerate(chart.metrics)
+            ]
+        case ESQLDatatableChart():
+            updates['metrics'] = [
+                _rewrite_esql_metric_static_value(
+                    metric,
+                    chart_type=chart.type,
+                    role=f'metric_{index}',
+                    eval_assignments=eval_assignments,
+                )
+                for index, metric in enumerate(chart.metrics)
+            ]
+        case ESQLTagcloudChart():
+            updates['metric'] = _rewrite_esql_metric_static_value(
+                chart.metric,
+                chart_type=chart.type,
+                role='metric',
+                eval_assignments=eval_assignments,
+            )
+        case ESQLMosaicChart():
+            updates['metric'] = _rewrite_esql_metric_static_value(
+                chart.metric,
+                chart_type=chart.type,
+                role='metric',
+                eval_assignments=eval_assignments,
+            )
+        case ESQLBarChart() | ESQLLineChart() | ESQLAreaChart():
+            updates['metrics'] = [
+                _rewrite_esql_xy_metric_static_value(
+                    metric,
+                    chart_type=chart.type,
+                    role=f'metric_{index}',
+                    eval_assignments=eval_assignments,
+                )
+                for index, metric in enumerate(chart.metrics)
+            ]
+
+    prepared_chart = chart.model_copy(update=updates) if len(updates) > 0 else chart
+    prepared_query = ESQLQuery(root=f'{query.root}\n| EVAL {", ".join(eval_assignments)}') if len(eval_assignments) > 0 else query
+
+    return prepared_chart, prepared_query
 
 
 def compile_lens_chart_state(  # noqa: PLR0912
@@ -207,30 +357,32 @@ def compile_esql_chart_state(panel: ESQLPanel) -> tuple[KbnLensPanelState, str]:
     text_based_datasource_state_layer_by_id: dict[str, KbnTextBasedDataSourceStateLayer] = {}
 
     chart = panel.esql
+    prepared_chart, prepared_query = _prepare_esql_chart_static_values(chart, query=chart.query)
+    compiled_query = compile_esql_query(prepared_query)
 
-    match chart:
+    match prepared_chart:
         case ESQLMetricChart():
-            layer_id, esql_columns, visualization_state = compile_esql_metric_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_metric_chart(prepared_chart)
         case ESQLGaugeChart():
-            layer_id, esql_columns, visualization_state = compile_esql_gauge_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_gauge_chart(prepared_chart)
         case ESQLHeatmapChart():
-            layer_id, esql_columns, visualization_state = compile_esql_heatmap_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_heatmap_chart(prepared_chart)
         case ESQLPieChart():
-            layer_id, esql_columns, visualization_state = compile_esql_pie_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_pie_chart(prepared_chart)
         case ESQLDatatableChart():
-            layer_id, esql_columns, visualization_state = compile_esql_datatable_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_datatable_chart(prepared_chart)
         case ESQLTagcloudChart():
-            layer_id, esql_columns, visualization_state = compile_esql_tagcloud_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_tagcloud_chart(prepared_chart)
         case ESQLMosaicChart():
-            layer_id, esql_columns, visualization_state = compile_esql_mosaic_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_mosaic_chart(prepared_chart)
         case ESQLBarChart() | ESQLLineChart() | ESQLAreaChart():
-            layer_id, esql_columns, visualization_state = compile_esql_xy_chart(chart)
+            layer_id, esql_columns, visualization_state = compile_esql_xy_chart(prepared_chart)
         case _:  # pyright: ignore[reportUnnecessaryComparison]
             msg = f'Unsupported ESQL chart type: {type(chart)}'
             raise NotImplementedError(msg)  # pyright: ignore[reportUnreachable]
 
     text_based_datasource_state_layer_by_id[layer_id] = KbnTextBasedDataSourceStateLayer(
-        query=compile_esql_query(chart.query),
+        query=compiled_query,
         columns=esql_columns,
         allColumns=esql_columns,
         timeField=panel.esql.time_field,
@@ -242,7 +394,7 @@ def compile_esql_chart_state(panel: ESQLPanel) -> tuple[KbnLensPanelState, str]:
 
     panel_state = KbnLensPanelState(
         visualization=visualization_state,
-        query=compile_esql_query(chart.query),
+        query=compiled_query,
         filters=[],
         datasourceStates=datasource_states,
         internalReferences=[],

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/gauge/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/gauge/compile.py
@@ -3,16 +3,191 @@
 from typing import TYPE_CHECKING
 
 from kb_dashboard_core.panels.charts.esql.columns.compile import compile_esql_metric
-from kb_dashboard_core.panels.charts.esql.columns.config import ESQLStaticValue
+from kb_dashboard_core.panels.charts.esql.columns.config import ESQLMetric, ESQLMetricTypes, ESQLStaticValue
 from kb_dashboard_core.panels.charts.esql.columns.view import KbnESQLColumnTypes
-from kb_dashboard_core.panels.charts.gauge.config import ESQLGaugeChart, LensGaugeChart
-from kb_dashboard_core.panels.charts.gauge.view import KbnGaugeVisualizationState
+from kb_dashboard_core.panels.charts.gauge.config import (
+    ESQLGaugeChart,
+    GaugeAppearance,
+    GaugeColorStop,
+    GaugePalette,
+    LensGaugeChart,
+)
+from kb_dashboard_core.panels.charts.gauge.view import (
+    KbnGaugeColorStop,
+    KbnGaugePalette,
+    KbnGaugePaletteParams,
+    KbnGaugeVisualizationState,
+)
 from kb_dashboard_core.panels.charts.lens.metrics.compile import compile_lens_metric
 from kb_dashboard_core.panels.charts.lens.metrics.config import LensStaticValue
+from kb_dashboard_core.queries.config import ESQLQuery
 from kb_dashboard_core.shared.compile import normalize_static_metric
 
 if TYPE_CHECKING:
     from kb_dashboard_core.panels.charts.lens.columns.view import KbnLensColumnTypes
+
+
+def _format_esql_numeric(value: int | float) -> str:
+    """Format a numeric value for inclusion in ESQL ``EVAL`` clauses."""
+    return str(value) if isinstance(value, int) else repr(value)
+
+
+def _compile_gauge_color_stops(stops: list[GaugeColorStop]) -> list[KbnGaugeColorStop]:
+    """Compile gauge color stops from config to view model."""
+    return [KbnGaugeColorStop(color=stop.color, stop=stop.stop) for stop in stops]
+
+
+def _derive_lower_bound_color_stops(
+    upper_stops: list[KbnGaugeColorStop],
+    range_min: int | float | None,
+) -> list[KbnGaugeColorStop]:
+    """Derive ``colorStops`` from upper-bound ``stops``.
+
+    Kibana expects both upper-bound ``stops`` and lower-bound ``colorStops`` for custom
+    palettes. If lower-bound stops are omitted in YAML, derive them by shifting each
+    band boundary.
+    """
+    if len(upper_stops) == 0:
+        return []
+
+    lower_bound = 0 if range_min is None else range_min
+    derived = [KbnGaugeColorStop(color=upper_stops[0].color, stop=lower_bound)]
+
+    for idx in range(1, len(upper_stops)):
+        prev_stop = upper_stops[idx - 1]
+        curr_stop = upper_stops[idx]
+        derived.append(KbnGaugeColorStop(color=curr_stop.color, stop=prev_stop.stop))
+
+    return derived
+
+
+def _compile_gauge_palette(
+    appearance: GaugeAppearance | None,
+    color_mode: str | None,
+) -> KbnGaugePalette | None:
+    """Compile gauge palette configuration.
+
+    When ``color_mode`` is ``palette`` but no explicit palette is provided, emit Kibana's
+    built-in ``status`` palette for sensible default red/yellow/green banding.
+    """
+    if color_mode != 'palette':
+        return None
+
+    palette_cfg: GaugePalette | None = appearance.palette if appearance is not None else None
+    if palette_cfg is None:
+        return KbnGaugePalette(
+            type='palette',
+            name='status',
+            params=KbnGaugePaletteParams(
+                name='status',
+                reverse=False,
+                rangeType='percent',
+                rangeMin=0,
+                rangeMax=100,
+                continuity='above',
+                steps=4,
+                maxSteps=5,
+                stops=[],
+                colorStops=[],
+            ),
+        )
+
+    stops = _compile_gauge_color_stops(palette_cfg.stops) if palette_cfg.stops is not None else None
+    color_stops = _compile_gauge_color_stops(palette_cfg.color_stops) if palette_cfg.color_stops is not None else None
+
+    if color_stops is None and stops is not None:
+        color_stops = _derive_lower_bound_color_stops(stops, palette_cfg.range_min)
+
+    params = KbnGaugePaletteParams(
+        name=palette_cfg.name,
+        reverse=palette_cfg.reverse,
+        rangeType=palette_cfg.range_type,
+        continuity=palette_cfg.continuity,
+        progression=palette_cfg.progression,
+        rangeMin=palette_cfg.range_min,
+        rangeMax=palette_cfg.range_max,
+        stops=stops,
+        colorStops=color_stops,
+        steps=palette_cfg.steps,
+        maxSteps=palette_cfg.max_steps,
+    )
+    params_model: KbnGaugePaletteParams | None = params if len(params.model_dump(exclude_none=True)) > 0 else None
+
+    return KbnGaugePalette(
+        type=palette_cfg.type,
+        name=palette_cfg.name,
+        params=params_model,
+    )
+
+
+def _esql_static_to_metric_column(metric: ESQLStaticValue, role: str) -> tuple[ESQLMetric, str]:
+    """Convert ESQL static gauge value to a generated ESQL field plus EVAL assignment."""
+    field_name = f'__kb_gauge_{role}_{metric.get_id().replace("-", "_")}'
+    label = metric.label if metric.label is not None else str(metric.value)
+    return (
+        ESQLMetric(
+            id=metric.get_id(),
+            field=field_name,
+            label=label,
+        ),
+        f'{field_name} = {_format_esql_numeric(metric.value)}',
+    )
+
+
+def prepare_esql_gauge_chart(
+    esql_gauge_chart: ESQLGaugeChart,
+    query: ESQLQuery | None = None,
+) -> tuple[ESQLGaugeChart, ESQLQuery | None]:
+    """Rewrite static ESQL gauge values into query-backed fields.
+
+    Kibana's text-based datasource does not support literal static value columns. Static
+    values for metric/min/max/goal are converted into generated fields via an appended
+    ``EVAL`` clause so that all gauge accessors reference actual query output columns.
+    """
+    updates: dict[str, object] = {}
+    eval_assignments: list[str] = []
+
+    normalized_metric = normalize_static_metric(esql_gauge_chart.metric, ESQLStaticValue)
+    if isinstance(normalized_metric, ESQLStaticValue):
+        metric_column, eval_assignment = _esql_static_to_metric_column(normalized_metric, role='metric')
+        updates['metric'] = metric_column
+        eval_assignments.append(eval_assignment)
+
+    def _rewrite_optional_metric(
+        value: ESQLMetricTypes | int | float | None,
+        role: str,
+    ) -> ESQLMetric | None:
+        if value is None:
+            return None
+        normalized = normalize_static_metric(value, ESQLStaticValue)
+        if isinstance(normalized, ESQLStaticValue):
+            metric_column, eval_assignment = _esql_static_to_metric_column(normalized, role=role)
+            eval_assignments.append(eval_assignment)
+            return metric_column
+        return normalized
+
+    minimum_metric = _rewrite_optional_metric(esql_gauge_chart.minimum, role='min')
+    if minimum_metric is not None:
+        updates['minimum'] = minimum_metric
+
+    maximum_metric = _rewrite_optional_metric(esql_gauge_chart.maximum, role='max')
+    if maximum_metric is not None:
+        updates['maximum'] = maximum_metric
+
+    goal_metric = _rewrite_optional_metric(esql_gauge_chart.goal, role='goal')
+    if goal_metric is not None:
+        updates['goal'] = goal_metric
+
+    if len(updates) == 0 and len(eval_assignments) == 0:
+        return esql_gauge_chart, query
+
+    prepared_chart = esql_gauge_chart.model_copy(update=updates) if len(updates) > 0 else esql_gauge_chart
+
+    if query is None or len(eval_assignments) == 0:
+        return prepared_chart, query
+
+    prepared_query = ESQLQuery(root=f'{query.root}\n| EVAL {", ".join(eval_assignments)}')
+    return prepared_chart, prepared_query
 
 
 def compile_gauge_chart_visualization_state(  # noqa: PLR0913
@@ -44,6 +219,7 @@ def compile_gauge_chart_visualization_state(  # noqa: PLR0913
     label_major = appearance.label_major if appearance is not None else None
     label_minor = appearance.label_minor if appearance is not None else None
     color_mode = appearance.color_mode if appearance is not None else None
+    palette = _compile_gauge_palette(appearance, color_mode)
 
     label_major_mode = 'custom' if label_major is not None else 'auto'
 
@@ -59,6 +235,7 @@ def compile_gauge_chart_visualization_state(  # noqa: PLR0913
         labelMinor=label_minor,
         labelMajorMode=label_major_mode,
         colorMode=color_mode,
+        palette=palette,
     )
 
 

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/gauge/config.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/gauge/config.py
@@ -17,7 +17,7 @@ class GaugeAppearance(BaseCfgModel):
     labels, and color mode.
     """
 
-    shape: Literal['horizontalBullet', 'verticalBullet', 'arc', 'circle'] | None = Field(default=None)
+    shape: Literal['horizontalBullet', 'verticalBullet', 'semiCircle', 'arc', 'circle'] | None = Field(default=None)
     """The shape of the gauge visualization."""
 
     ticks_position: Literal['auto', 'bands', 'hidden'] | None = Field(default=None)
@@ -31,6 +31,59 @@ class GaugeAppearance(BaseCfgModel):
 
     color_mode: Literal['none', 'palette'] | None = Field(default=None)
     """Color mode for the gauge visualization."""
+
+    palette: 'GaugePalette | None' = Field(default=None)
+    """Optional palette configuration used when ``color_mode`` is ``palette``."""
+
+
+class GaugeColorStop(BaseCfgModel):
+    """A color stop for gauge palette thresholds."""
+
+    color: str = Field(...)
+    """Hex color value, for example ``#209280``."""
+
+    stop: int | float = Field(...)
+    """Threshold stop value for this color."""
+
+
+class GaugePalette(BaseCfgModel):
+    """Gauge palette configuration matching Kibana's palette output parameters."""
+
+    type: Literal['palette', 'system_palette'] = Field(default='palette')
+    """Palette type. ``palette`` is the common choice for gauge color bands."""
+
+    name: str = Field(default='status')
+    """Palette name. ``status`` is Kibana's default red/yellow/green style."""
+
+    reverse: bool | None = Field(default=None)
+    """Reverse palette ordering."""
+
+    range_type: Literal['number', 'percent'] | None = Field(default=None)
+    """Range type for stop interpretation."""
+
+    continuity: Literal['above', 'below', 'none', 'all'] | None = Field(default=None)
+    """Continuity behavior between color bands."""
+
+    progression: Literal['fixed'] | None = Field(default=None)
+    """Band progression mode."""
+
+    range_min: int | float | None = Field(default=None)
+    """Lower bound for palette range."""
+
+    range_max: int | float | None = Field(default=None)
+    """Upper bound for palette range."""
+
+    stops: list[GaugeColorStop] | None = Field(default=None)
+    """Upper-bound color stops."""
+
+    color_stops: list[GaugeColorStop] | None = Field(default=None)
+    """Lower-bound color stops. If omitted, they are derived from ``stops``."""
+
+    steps: int | None = Field(default=None)
+    """Number of color steps."""
+
+    max_steps: int | None = Field(default=None)
+    """Maximum number of color steps."""
 
 
 class BaseGaugeChart(BaseCfgModel):

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/gauge/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/gauge/view.py
@@ -13,6 +13,40 @@ from pydantic import Field
 from kb_dashboard_core.shared.view import BaseVwModel, OmitIfNone
 
 
+class KbnGaugeColorStop(BaseVwModel):
+    """A color stop in Kibana gauge palette format."""
+
+    color: str = Field(...)
+    """Hex color value, for example ``#209280``."""
+
+    stop: int | float = Field(...)
+    """Threshold stop value."""
+
+
+class KbnGaugePaletteParams(BaseVwModel):
+    """Palette parameters for Kibana gauge visualizations."""
+
+    name: Annotated[str | None, OmitIfNone()] = Field(default=None)
+    reverse: Annotated[bool | None, OmitIfNone()] = Field(default=None)
+    rangeType: Annotated[Literal['number', 'percent'] | None, OmitIfNone()] = Field(default=None)
+    continuity: Annotated[Literal['above', 'below', 'none', 'all'] | None, OmitIfNone()] = Field(default=None)
+    progression: Annotated[Literal['fixed'] | None, OmitIfNone()] = Field(default=None)
+    rangeMin: Annotated[int | float | None, OmitIfNone()] = Field(default=None)
+    rangeMax: Annotated[int | float | None, OmitIfNone()] = Field(default=None)
+    stops: Annotated[list[KbnGaugeColorStop] | None, OmitIfNone()] = Field(default=None)
+    colorStops: Annotated[list[KbnGaugeColorStop] | None, OmitIfNone()] = Field(default=None)
+    steps: Annotated[int | None, OmitIfNone()] = Field(default=None)
+    maxSteps: Annotated[int | None, OmitIfNone()] = Field(default=None)
+
+
+class KbnGaugePalette(BaseVwModel):
+    """Palette output model used by Kibana gauge visualization state."""
+
+    type: Literal['palette', 'system_palette'] = Field(default='palette')
+    name: str = Field(default='status')
+    params: Annotated[KbnGaugePaletteParams | None, OmitIfNone()] = Field(default=None)
+
+
 class KbnGaugeVisualizationState(BaseVwModel):
     """View model for gauge visualization state after compilation to Kibana Lens format.
 
@@ -50,7 +84,7 @@ class KbnGaugeVisualizationState(BaseVwModel):
     goalAccessor: Annotated[str | None, OmitIfNone()] = Field(default=None)
     """Field accessor ID for the goal/target metric (shown as reference line)."""
 
-    shape: Literal['horizontalBullet', 'verticalBullet', 'arc', 'circle'] = Field(default='arc')
+    shape: Literal['horizontalBullet', 'verticalBullet', 'semiCircle', 'arc', 'circle'] = Field(default='arc')
     """The shape of the gauge visualization. Defaults to 'arc'."""
 
     ticksPosition: Literal['auto', 'bands', 'hidden'] = Field(default='auto')
@@ -67,3 +101,6 @@ class KbnGaugeVisualizationState(BaseVwModel):
 
     colorMode: Annotated[Literal['none', 'palette'] | None, OmitIfNone()] = Field(default=None)
     """Color mode for the gauge visualization."""
+
+    palette: Annotated[KbnGaugePalette | None, OmitIfNone()] = Field(default=None)
+    """Palette configuration for ``colorMode='palette'``."""

--- a/packages/kb-dashboard-core/tests/panels/charts/gauge/test_gauge.py
+++ b/packages/kb-dashboard-core/tests/panels/charts/gauge/test_gauge.py
@@ -230,13 +230,29 @@ def test_compile_gauge_chart_with_all_options_lens() -> None:
             'labelMinor': 'Percentage',
             'labelMajorMode': 'custom',
             'colorMode': 'palette',
+            'palette': {
+                'type': 'palette',
+                'name': 'status',
+                'params': {
+                    'name': 'status',
+                    'reverse': False,
+                    'rangeType': 'percent',
+                    'continuity': 'above',
+                    'rangeMin': 0,
+                    'rangeMax': 100,
+                    'stops': [],
+                    'colorStops': [],
+                    'steps': 4,
+                    'maxSteps': 5,
+                },
+            },
         }
     )
 
 
 def test_compile_gauge_chart_with_all_shapes() -> None:
     """Test the compilation of gauge charts with different shape options."""
-    shapes = ['horizontalBullet', 'verticalBullet', 'arc', 'circle']
+    shapes = ['horizontalBullet', 'verticalBullet', 'semiCircle', 'arc', 'circle']
 
     for shape in shapes:
         config = {
@@ -257,6 +273,62 @@ def test_compile_gauge_chart_with_all_shapes() -> None:
         assert result['shape'] == shape
         assert result['layerType'] == 'data'
         assert result['metricAccessor'] == 'metric_accessor'
+
+
+def test_compile_gauge_chart_with_custom_palette_lens() -> None:
+    """Test custom gauge palette compilation with derived lower-bound stops."""
+    config = {
+        'type': 'gauge',
+        'data_view': 'metrics-*',
+        'metric': {
+            'field': 'system.cpu.total.pct',
+            'id': 'metric_accessor',
+            'aggregation': 'average',
+        },
+        'appearance': {
+            'shape': 'arc',
+            'color_mode': 'palette',
+            'palette': {
+                'name': 'custom',
+                'range_type': 'percent',
+                'range_min': 0,
+                'range_max': 100,
+                'continuity': 'above',
+                'stops': [
+                    {'color': '#cc5642', 'stop': 75},
+                    {'color': '#d6bf57', 'stop': 95},
+                    {'color': '#209280', 'stop': 100},
+                ],
+            },
+        },
+    }
+
+    result = compile_gauge_chart_snapshot(config, 'lens')
+
+    assert result['colorMode'] == 'palette'
+    assert result['palette'] == snapshot(
+        {
+            'type': 'palette',
+            'name': 'custom',
+            'params': {
+                'name': 'custom',
+                'rangeType': 'percent',
+                'continuity': 'above',
+                'rangeMin': 0,
+                'rangeMax': 100,
+                'stops': [
+                    {'color': '#cc5642', 'stop': 75},
+                    {'color': '#d6bf57', 'stop': 95},
+                    {'color': '#209280', 'stop': 100},
+                ],
+                'colorStops': [
+                    {'color': '#cc5642', 'stop': 0},
+                    {'color': '#d6bf57', 'stop': 75},
+                    {'color': '#209280', 'stop': 95},
+                ],
+            },
+        }
+    )
 
 
 def test_compile_gauge_chart_with_ticks_positions() -> None:

--- a/packages/kb-dashboard-core/tests/panels/charts/test_compile_charts.py
+++ b/packages/kb-dashboard-core/tests/panels/charts/test_compile_charts.py
@@ -919,6 +919,176 @@ class TestCompileESQLChartState:
             assert layer_id in layers
             assert state.adHocDataViews == {}
 
+    def test_esql_gauge_static_values_are_rewritten_to_eval_fields(self) -> None:
+        """Test that static gauge min/max/goal values compile to EVAL-backed ESQL fields."""
+        from kb_dashboard_core.panels.charts.config import ESQLPanel
+
+        panel = ESQLPanel.model_validate(
+            {
+                'position': {'x': 0, 'y': 0},
+                'size': {'w': 24, 'h': 15},
+                'esql': {
+                    'type': 'gauge',
+                    'query': 'FROM logs-* | STATS hit_ratio = AVG(cache.hit.ratio)',
+                    'metric': {'field': 'hit_ratio', 'id': 'metric1'},
+                    'minimum': 0,
+                    'maximum': 1,
+                    'goal': 0.95,
+                },
+            }
+        )
+
+        state, _ = compile_esql_chart_state(panel)
+        assert state.datasourceStates.textBased is not None
+        assert state.datasourceStates.textBased.layers is not None
+        layer = next(iter(state.datasourceStates.textBased.layers.root.values()))
+
+        # Query gets rewritten with synthetic EVAL fields for static values.
+        assert '| EVAL ' in layer.query.esql
+        assert '__kb_gauge_min_' in layer.query.esql
+        assert '__kb_gauge_max_' in layer.query.esql
+        assert '__kb_gauge_goal_' in layer.query.esql
+
+        # Columns reference generated field names instead of literal "0", "1", "0.95".
+        field_names = {column.fieldName for column in layer.columns}
+        assert '0' not in field_names
+        assert '1' not in field_names
+        assert '0.95' not in field_names
+        assert any(name.startswith('__kb_gauge_min_') for name in field_names)
+        assert any(name.startswith('__kb_gauge_max_') for name in field_names)
+        assert any(name.startswith('__kb_gauge_goal_') for name in field_names)
+
+        # Gauge accessors point to those generated fields.
+        visualization = state.visualization.model_dump()
+        field_by_id = {column.columnId: column.fieldName for column in layer.columns}
+        assert field_by_id[visualization['minAccessor']].startswith('__kb_gauge_min_')
+        assert field_by_id[visualization['maxAccessor']].startswith('__kb_gauge_max_')
+        assert field_by_id[visualization['goalAccessor']].startswith('__kb_gauge_goal_')
+
+        # Panel-level query and layer-level query stay in sync.
+        assert state.query.esql == layer.query.esql
+
+    def test_esql_gauge_static_metric_is_rewritten_to_eval_field(self) -> None:
+        """Test that static gauge metric values compile to EVAL-backed ESQL fields."""
+        from kb_dashboard_core.panels.charts.config import ESQLPanel
+
+        panel = ESQLPanel.model_validate(
+            {
+                'position': {'x': 0, 'y': 0},
+                'size': {'w': 24, 'h': 15},
+                'esql': {
+                    'type': 'gauge',
+                    'query': 'FROM logs-* | LIMIT 1',
+                    'metric': {'value': 0.97, 'id': 'metric_static'},
+                    'minimum': 0,
+                    'maximum': 1,
+                    'goal': 0.95,
+                },
+            }
+        )
+
+        state, _ = compile_esql_chart_state(panel)
+        assert state.datasourceStates.textBased is not None
+        assert state.datasourceStates.textBased.layers is not None
+        layer = next(iter(state.datasourceStates.textBased.layers.root.values()))
+
+        assert '__kb_gauge_metric_' in layer.query.esql
+        field_names = {column.fieldName for column in layer.columns}
+        assert any(name.startswith('__kb_gauge_metric_') for name in field_names)
+
+    @pytest.mark.parametrize(
+        ('chart_config', 'expected_prefix'),
+        [
+            (
+                {
+                    'type': 'metric',
+                    'query': 'FROM logs-* | LIMIT 1',
+                    'primary': {'value': 10, 'id': 'metric_static'},
+                },
+                '__kb_metric_primary_',
+            ),
+            (
+                {
+                    'type': 'pie',
+                    'query': 'FROM logs-* | STATS c = COUNT(*) BY status',
+                    'dimensions': [{'field': 'status', 'id': 'dim1'}],
+                    'metrics': [{'value': 10, 'id': 'metric_static'}],
+                },
+                '__kb_pie_metric_0_',
+            ),
+            (
+                {
+                    'type': 'datatable',
+                    'query': 'FROM logs-* | LIMIT 1',
+                    'metrics': [{'value': 10, 'id': 'metric_static'}],
+                },
+                '__kb_datatable_metric_0_',
+            ),
+            (
+                {
+                    'type': 'heatmap',
+                    'query': 'FROM logs-* | STATS c = COUNT(*) BY x, y',
+                    'x_axis': {'field': 'x', 'id': 'x1'},
+                    'y_axis': {'field': 'y', 'id': 'y1'},
+                    'value': {'value': 10, 'id': 'metric_static'},
+                },
+                '__kb_heatmap_value_',
+            ),
+            (
+                {
+                    'type': 'tagcloud',
+                    'query': 'FROM logs-* | STATS c = COUNT(*) BY tag',
+                    'dimension': {'field': 'tag', 'id': 'dim1'},
+                    'metric': {'value': 10, 'id': 'metric_static'},
+                },
+                '__kb_tagcloud_metric_',
+            ),
+            (
+                {
+                    'type': 'mosaic',
+                    'query': 'FROM logs-* | STATS c = COUNT(*) BY tag',
+                    'dimension': {'field': 'tag', 'id': 'dim1'},
+                    'metric': {'value': 10, 'id': 'metric_static'},
+                },
+                '__kb_mosaic_metric_',
+            ),
+            (
+                {
+                    'type': 'bar',
+                    'query': 'FROM logs-* | STATS c = COUNT(*) BY category',
+                    'dimension': {'field': 'category', 'id': 'dim1'},
+                    'metrics': [{'value': 10, 'id': 'metric_static'}],
+                },
+                '__kb_bar_metric_0_',
+            ),
+        ],
+    )
+    def test_esql_static_metrics_are_rewritten_across_chart_types(
+        self,
+        chart_config: dict[str, object],
+        expected_prefix: str,
+    ) -> None:
+        """Test that all ES|QL chart types rewrite static metrics into EVAL-backed fields."""
+        from kb_dashboard_core.panels.charts.config import ESQLPanel
+
+        panel = ESQLPanel.model_validate(
+            {
+                'position': {'x': 0, 'y': 0},
+                'size': {'w': 24, 'h': 15},
+                'esql': chart_config,
+            }
+        )
+
+        state, _ = compile_esql_chart_state(panel)
+        assert state.datasourceStates.textBased is not None
+        assert state.datasourceStates.textBased.layers is not None
+        layer = next(iter(state.datasourceStates.textBased.layers.root.values()))
+
+        assert '| EVAL ' in layer.query.esql
+        field_names = {column.fieldName for column in layer.columns}
+        assert '10' not in field_names
+        assert any(name.startswith(expected_prefix) for name in field_names)
+
 
 class TestESQLDataTypeDate:
     """Tests for ES|QL dimension data_type: date feature.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fixes two gauge chart compilation bugs:

1. **ESQL static values (#1185):** ES|QL gauge charts with static numeric `minimum`, `maximum`, or `goal` values compiled to columns with `fieldName` set to the literal number (`"0"`, `"1"`, `"0.95"`). Kibana's text-based datasource treats `fieldName` as a query output column reference, so those panels failed with _"Provided column name or index is invalid"_. The fix rewrites static values into synthetic `EVAL`-backed fields before compilation.

2. **Gauge palette (#1186):** Gauge charts with `color_mode: palette` compiled without a `palette` object, so Kibana fell back to rendering the arc in a single default color. The fix emits the required `palette` configuration — defaulting to Kibana's built-in `status` palette when no custom stops are provided.

Bonus: adds `semiCircle` to the allowed `GaugeAppearance.shape` values, which was already present in Kibana but missing from the config/view enums.

## Changes

**ES|QL static values (fixes #1185):**

- Add `_prepare_esql_chart_static_values()` in `compile.py` that rewrites static metrics to synthetic `EVAL` fields for all ES|QL chart types (gauge, metric, pie, datatable, heatmap, tagcloud, mosaic, bar, line, area)
- Add `prepare_esql_gauge_chart()` in `gauge/compile.py` for gauge-specific rewriting of static metric/min/max/goal values; the compiled query gets `| EVAL __kb_gauge_<role>_<id> = <value>` appended automatically
- All gauge accessors now reference the generated field names rather than raw numeric strings

**Gauge palette (fixes #1186):**

- Add `GaugeColorStop` and `GaugePalette` config models to `gauge/config.py`
- Add `palette` field to `GaugeAppearance`
- Add `KbnGaugeColorStop`, `KbnGaugePaletteParams`, `KbnGaugePalette` view models to `gauge/view.py`
- Add `palette` field to `KbnGaugeVisualizationState`
- `_compile_gauge_palette()` defaults to Kibana's built-in `status` palette when `color_mode: palette` is set without explicit stops; derives lower-bound `colorStops` automatically when only upper-bound `stops` are provided

**Gauge shape:**

- Add `semiCircle` to the allowed shape literals in both `GaugeAppearance` (config) and `KbnGaugeVisualizationState` (view)

## Testing Instructions

### Test Sample Config

```yaml
# ES|QL gauge with static values (fixes #1185) and palette (fixes #1186)
- title: Cache Hit Ratio Gauge
  size: {w: 16, h: 10}
  esql:
    type: gauge
    query: |
      FROM metrics-*
      | STATS hits = SUM(hit_count), misses = SUM(miss_count)
      | EVAL hit_ratio = CASE(hits + misses > 0, hits / (hits + misses), 0)
    metric:
      field: hit_ratio
      label: Cache Hit Ratio
      format:
        type: percent
        decimals: 1
    minimum: 0
    maximum: 1
    goal: 0.95
    appearance:
      shape: arc
      color_mode: palette         # emits built-in status palette by default
      # palette:                  # optional: provide custom stops
      #   range_type: percent
      #   continuity: above
      #   stops:
      #     - color: "#cc5642"
      #       stop: 75
      #     - color: "#d6bf57"
      #       stop: 95
      #     - color: "#209280"
      #       stop: 100
```

### Expected Outcome

- The compiled query contains `| EVAL __kb_gauge_min_<id> = 0, __kb_gauge_max_<id> = 1, __kb_gauge_goal_<id> = 0.95` appended automatically
- Compiled columns reference the synthetic `__kb_gauge_*` field names instead of `"0"`, `"1"`, `"0.95"`
- `visualization.colorMode` is `"palette"` and `visualization.palette` is present with the `status` palette (or custom stops if configured)

### How to Verify

```bash
# Example verification commands (run from repository root)
make all install
make core test
```

## Related Issues

Fixes #1185
Fixes #1186

## Checklist

- [x] All static checks pass (`make all ci`)
- [x] I followed the [contributing guide](CONTRIBUTING.md)
- [x] Tests added/updated as needed
- [ ] Documentation updated (if API changed)
- [ ] Breaking changes documented with migration path
- [x] Self-review completed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite ES|QL static metric values into EVAL-backed synthetic fields and add gauge palette support
> - Static numeric values in ES|QL chart metrics (gauge, metric, pie, XY, etc.) are now rewritten into synthetic fields via EVAL clauses, so downstream compilation always works with field-backed columns rather than literals.
> - Adds `prepare_esql_gauge_chart` in [gauge/compile.py](https://github.com/strawgate/kb-yaml-to-lens/pull/1189/files#diff-ee9fc2646f04bf697c7e8e56d103831ddb8757f0485e9e45a635e0246d30fa16) to handle gauge-specific static fields (metric, min, max, goal) and `_prepare_esql_chart_static_values` in [compile.py](https://github.com/strawgate/kb-yaml-to-lens/pull/1189/files#diff-28dda3657257aa0f4fbda3a5e3c956797fbb14bc517b7b021c83724a301b0f51) for all other chart types.
> - Gauge visualization state now includes a `palette` object when `color_mode='palette'`, with new `GaugePalette`/`GaugeColorStop` config models and corresponding view models.
> - Adds `semiCircle` as a valid gauge shape option in `GaugeAppearance`.
> - Behavioral Change: the panel-level and layer-level ES|QL queries are now always identical and include any generated EVAL assignments.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 799020d. 6 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ES|QL charts now support static metric values
  * Gauge charts introduce palette-based coloring with customizable color stops
  * Added semiCircle shape option for gauge visualization
  * Enhanced gauge appearance configuration with palette parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->