### PR TITLE
fix(preview): correct section layout and add grid extractor tests

### DIFF
--- a/packages/kb-dashboard-cli/src/dashboard_compiler/lsp/grid_extractor.py
+++ b/packages/kb-dashboard-cli/src/dashboard_compiler/lsp/grid_extractor.py
@@ -13,23 +13,32 @@ import sys
 from kb_dashboard_core.dashboard_compiler import load
 from kb_dashboard_core.panels.collapsible import CollapsiblePanel
 from kb_dashboard_core.panels.compile import compute_panel_positions
-from kb_dashboard_core.panels.config import GRID_WIDTH_WHOLE, resolve_semantic_width
+from kb_dashboard_core.panels.config import GRID_WIDTH_WHOLE, Size, resolve_semantic_width
 
 from dashboard_compiler.lsp.models import DashboardGridInfo, Grid, PanelGridInfo
 from dashboard_compiler.lsp.utils import get_panel_type
 
 
-def _extract_inner_panels(section_panel: CollapsiblePanel) -> list[PanelGridInfo]:
-    """Extract inner panels from a CollapsiblePanel section with auto-layout."""
+def _extract_inner_panels(section_panel: CollapsiblePanel) -> tuple[list[PanelGridInfo], int]:
+    """Extract inner panels from a CollapsiblePanel section with auto-layout.
+
+    Inner panels use a **relative** coordinate space — their (x, y) positions
+    start at (0, 0) within the section body, independent of the section's
+    absolute position in the outer dashboard grid.
+
+    Returns:
+        Tuple of (inner panel grid infos, content height in grid rows).
+    """
     inner_source = section_panel.section.panels
     if not inner_source:
-        return []
+        return [], 0
 
     # Filter out nested CollapsiblePanels (not supported) for layout
     layout_panels = [p for p in inner_source if not isinstance(p, CollapsiblePanel)]
     position_map = compute_panel_positions(layout_panels)
 
     result: list[PanelGridInfo] = []
+    max_bottom = 0
     layout_idx = 0
     for inner in inner_source:
         if isinstance(inner, CollapsiblePanel):
@@ -45,6 +54,10 @@ def _extract_inner_panels(section_panel: CollapsiblePanel) -> list[PanelGridInfo
             layout_idx += 1
             continue
 
+        bottom = iy + inner.size.h
+        if bottom > max_bottom:
+            max_bottom = bottom
+
         result.append(
             PanelGridInfo(
                 id=inner.id if (inner.id is not None and len(inner.id) > 0) else f'inner_{layout_idx}',
@@ -56,7 +69,7 @@ def _extract_inner_panels(section_panel: CollapsiblePanel) -> list[PanelGridInfo
         )
         layout_idx += 1
 
-    return result
+    return result, max_bottom
 
 
 def extract_grid_layout(yaml_path: str, dashboard_index: int = 0) -> DashboardGridInfo:
@@ -80,37 +93,36 @@ def extract_grid_layout(yaml_path: str, dashboard_index: int = 0) -> DashboardGr
 
     dashboard_config = dashboards[dashboard_index]
 
-    # Filter out CollapsiblePanels for auto-layout (they are full-width section headers)
-    layout_panels = [p for p in dashboard_config.panels if not isinstance(p, CollapsiblePanel)]
+    # First pass: extract inner panels for each section and compute effective heights.
+    #
+    # Sections have h=1 (header bar) in the output, but their visual footprint in the
+    # preview is header + inner panel content. We create height-inflated copies for layout
+    # computation so the auto-layout engine reserves the right amount of vertical space,
+    # preventing panels after a section from overlapping its inner content.
+    # The inflated copies are only used for position computation — the output always
+    # emits h=1 for sections.
+    all_panels = list(dashboard_config.panels)
+    section_data: dict[int, tuple[list[PanelGridInfo], int]] = {}
+    layout_panels = []
+    for idx, panel in enumerate(all_panels):
+        if isinstance(panel, CollapsiblePanel):
+            inner_panels, content_h = _extract_inner_panels(panel)
+            section_data[idx] = (inner_panels, content_h)
+            # Create a copy with effective height (header + content) for layout only
+            effective_h = 1 + content_h
+            adjusted = panel.model_copy(update={'size': Size(w=GRID_WIDTH_WHOLE, h=effective_h)})
+            layout_panels.append(adjusted)
+        else:
+            layout_panels.append(panel)
+
     position_map = compute_panel_positions(layout_panels, algorithm=dashboard_config.settings.layout_algorithm)
 
-    # Extract panel information
+    # Second pass: build output with correct positions but original section h=1
     panels: list[PanelGridInfo] = []
-    layout_index = 0
-    for panel in dashboard_config.panels:
-        if isinstance(panel, CollapsiblePanel):
-            # Section headers are full-width, 1 row tall; position from the panel itself
-            x = panel.position.x if panel.position.x is not None else 0
-            y = panel.position.y if panel.position.y is not None else 0
-
-            # Extract inner panels with their own auto-layout
-            inner_panels = _extract_inner_panels(panel)
-
-            panel_info = PanelGridInfo(
-                id=panel.id if (panel.id is not None and len(panel.id) > 0) else f'section_{panel.title or "Untitled Section"}',
-                title=panel.title if (panel.title is not None and len(panel.title) > 0) else 'Untitled Section',
-                type='section',
-                grid=Grid(x=x, y=y, w=GRID_WIDTH_WHOLE, h=1),
-                is_pinned=panel.position.x is not None and panel.position.y is not None,
-                panels=inner_panels,
-            )
-            panels.append(panel_info)
-            continue
-
+    for idx, panel in enumerate(all_panels):
         # Use computed position if available, otherwise use panel's position
-        # A panel is "pinned" if it has explicit position coordinates (not auto-positioned)
-        if layout_index in position_map:
-            x, y = position_map[layout_index]
+        if idx in position_map:
+            x, y = position_map[idx]
             is_pinned = False
         elif panel.position.x is not None and panel.position.y is not None:
             x, y = panel.position.x, panel.position.y
@@ -119,15 +131,26 @@ def extract_grid_layout(yaml_path: str, dashboard_index: int = 0) -> DashboardGr
             msg = f'Panel "{panel.title}" has no position and auto-layout failed'
             raise ValueError(msg)
 
-        panel_info = PanelGridInfo(
-            id=panel.id if (panel.id is not None and len(panel.id) > 0) else f'panel_{layout_index}',
-            title=panel.title if (panel.title is not None and len(panel.title) > 0) else 'Untitled Panel',
-            type=get_panel_type(panel),
-            grid=Grid(x=x, y=y, w=resolve_semantic_width(panel.size.w), h=panel.size.h),
-            is_pinned=is_pinned,
-        )
+        if isinstance(panel, CollapsiblePanel):
+            inner_panels, _content_h = section_data[idx]
+
+            panel_info = PanelGridInfo(
+                id=panel.id if (panel.id is not None and len(panel.id) > 0) else f'section_{panel.title or "Untitled Section"}',
+                title=panel.title if (panel.title is not None and len(panel.title) > 0) else 'Untitled Section',
+                type='section',
+                grid=Grid(x=x, y=y, w=GRID_WIDTH_WHOLE, h=1),
+                is_pinned=is_pinned,
+                panels=inner_panels,
+            )
+        else:
+            panel_info = PanelGridInfo(
+                id=panel.id if (panel.id is not None and len(panel.id) > 0) else f'panel_{idx}',
+                title=panel.title if (panel.title is not None and len(panel.title) > 0) else 'Untitled Panel',
+                type=get_panel_type(panel),
+                grid=Grid(x=x, y=y, w=resolve_semantic_width(panel.size.w), h=panel.size.h),
+                is_pinned=is_pinned,
+            )
         panels.append(panel_info)
-        layout_index += 1
 
     title = dashboard_config.name if (dashboard_config.name is not None and len(dashboard_config.name) > 0) else 'Untitled Dashboard'
     description = (

--- a/packages/kb-dashboard-cli/tests/lsp/test_grid_extractor.py
+++ b/packages/kb-dashboard-cli/tests/lsp/test_grid_extractor.py
@@ -1,0 +1,393 @@
+"""Tests for grid extractor — extracting panel layout info for the VS Code preview."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dashboard_compiler.lsp.grid_extractor import extract_grid_layout
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    yaml_path = tmp_path / 'dashboard.yaml'
+    yaml_path.write_text(textwrap.dedent(content), encoding='utf-8')
+    return yaml_path
+
+
+# ---------------------------------------------------------------------------
+# Basic extraction (no sections)
+# ---------------------------------------------------------------------------
+
+class TestBasicExtraction:
+    """Grid extraction for dashboards without collapsible sections."""
+
+    def test_single_panel(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Simple"
+                panels:
+                  - title: "Panel A"
+                    size: {w: 48, h: 6}
+                    markdown:
+                      content: "Hello"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert result.title == "Simple"
+        assert len(result.panels) == 1
+        p = result.panels[0]
+        assert p.title == "Panel A"
+        assert p.grid.x == 0
+        assert p.grid.y == 0
+        assert p.grid.w == 48
+        assert p.grid.h == 6
+        assert p.type == "markdown"
+        assert p.panels == []
+
+    def test_two_panels_auto_layout(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Two Panels"
+                panels:
+                  - title: "A"
+                    size: {w: 24, h: 4}
+                    markdown:
+                      content: "A"
+                  - title: "B"
+                    size: {w: 24, h: 4}
+                    markdown:
+                      content: "B"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert len(result.panels) == 2
+        # Side by side (both fit in 48 columns)
+        a, b = result.panels
+        assert a.grid.y == 0
+        assert b.grid.y == 0
+        assert a.grid.x != b.grid.x
+
+
+# ---------------------------------------------------------------------------
+# Sections in layout flow
+# ---------------------------------------------------------------------------
+
+class TestSectionLayout:
+    """Sections participate in auto-layout with correct Y coordinates."""
+
+    def test_section_gets_auto_position(self, tmp_path: Path) -> None:
+        """A section without explicit position gets placed after preceding panels."""
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "With Section"
+                panels:
+                  - title: "Header"
+                    size: {w: 48, h: 6}
+                    markdown:
+                      content: "Top"
+                  - title: "Details"
+                    section:
+                      panels:
+                        - title: "Inner"
+                          size: {w: 48, h: 8}
+                          markdown:
+                            content: "Inside"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert len(result.panels) == 2
+
+        header, section = result.panels
+        assert header.grid.y == 0
+        assert header.grid.h == 6
+
+        # Section positioned after header
+        assert section.grid.y == 6
+        assert section.grid.h == 1  # Always h=1 in output
+        assert section.type == "section"
+
+    def test_panel_after_section_not_overlapping(self, tmp_path: Path) -> None:
+        """Panels after a section are placed below the section's full footprint."""
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Section Then Panel"
+                panels:
+                  - title: "Top"
+                    size: {w: 48, h: 4}
+                    markdown:
+                      content: "Top"
+                  - title: "My Section"
+                    section:
+                      panels:
+                        - title: "Inner A"
+                          size: {w: 48, h: 10}
+                          markdown:
+                            content: "A"
+                  - title: "Bottom"
+                    size: {w: 48, h: 4}
+                    markdown:
+                      content: "Bottom"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert len(result.panels) == 3
+
+        top, section, bottom = result.panels
+        # Top panel: y=0, h=4
+        assert top.grid.y == 0
+        # Section: y=4, h=1 (but inner content is 10 rows)
+        assert section.grid.y == 4
+        assert section.grid.h == 1
+        # Bottom panel must start after section header (1) + inner content (10) = y >= 15
+        assert bottom.grid.y >= section.grid.y + 1 + 10
+
+    def test_multiple_consecutive_sections(self, tmp_path: Path) -> None:
+        """Multiple sections in a row each get correct Y positions."""
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Multi Section"
+                panels:
+                  - title: "Section A"
+                    section:
+                      panels:
+                        - title: "Inner A"
+                          size: {w: 48, h: 6}
+                          markdown:
+                            content: "A"
+                  - title: "Section B"
+                    section:
+                      panels:
+                        - title: "Inner B"
+                          size: {w: 48, h: 8}
+                          markdown:
+                            content: "B"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert len(result.panels) == 2
+
+        sec_a, sec_b = result.panels
+        assert sec_a.grid.y == 0
+        assert sec_a.grid.h == 1
+        # Section B starts after Section A header (1) + inner content (6) = 7
+        assert sec_b.grid.y >= sec_a.grid.y + 1 + 6
+
+
+# ---------------------------------------------------------------------------
+# Section inner panels
+# ---------------------------------------------------------------------------
+
+class TestSectionInnerPanels:
+    """Inner panels use relative coordinates within the section."""
+
+    def test_inner_panels_have_relative_coordinates(self, tmp_path: Path) -> None:
+        """Inner panel Y coordinates start at 0, not at the section's outer Y."""
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Inner Coords"
+                panels:
+                  - title: "Spacer"
+                    size: {w: 48, h: 20}
+                    markdown:
+                      content: "Spacer"
+                  - title: "My Section"
+                    section:
+                      panels:
+                        - title: "Inner"
+                          size: {w: 48, h: 8}
+                          markdown:
+                            content: "Inside"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        section = result.panels[1]
+        assert section.grid.y == 20  # After the spacer
+
+        # Inner panel coordinates are relative to section body
+        assert len(section.panels) == 1
+        inner = section.panels[0]
+        assert inner.grid.y == 0  # Relative, not absolute
+        assert inner.grid.x == 0
+
+    def test_multiple_inner_panels_auto_layout(self, tmp_path: Path) -> None:
+        """Inner panels get auto-laid out within the section's coordinate space."""
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Multi Inner"
+                panels:
+                  - title: "Section"
+                    section:
+                      panels:
+                        - title: "Left"
+                          size: {w: 16, h: 8}
+                          markdown:
+                            content: "L"
+                        - title: "Middle"
+                          size: {w: 16, h: 8}
+                          markdown:
+                            content: "M"
+                        - title: "Right"
+                          size: {w: 16, h: 8}
+                          markdown:
+                            content: "R"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        section = result.panels[0]
+        assert len(section.panels) == 3
+
+        # All three fit in one row (16*3 = 48)
+        for inner in section.panels:
+            assert inner.grid.y == 0
+            assert inner.grid.w == 16
+        # Different x positions
+        xs = [p.grid.x for p in section.panels]
+        assert len(set(xs)) == 3
+
+    def test_inner_panels_with_explicit_positions(self, tmp_path: Path) -> None:
+        """Inner panels with explicit positions are marked as pinned."""
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Pinned Inner"
+                panels:
+                  - title: "Section"
+                    section:
+                      panels:
+                        - title: "Pinned"
+                          size: {w: 24, h: 8}
+                          position: {x: 10, y: 5}
+                          markdown:
+                            content: "P"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        section = result.panels[0]
+        inner = section.panels[0]
+        assert inner.grid.x == 10
+        assert inner.grid.y == 5
+        assert inner.is_pinned is True
+
+
+# ---------------------------------------------------------------------------
+# Empty sections
+# ---------------------------------------------------------------------------
+
+class TestEmptySection:
+    """Empty sections have no inner panels and minimal footprint."""
+
+    def test_empty_section(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Empty Section"
+                panels:
+                  - title: "Empty"
+                    section:
+                      panels: []
+                  - title: "After"
+                    size: {w: 48, h: 4}
+                    markdown:
+                      content: "After"
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert len(result.panels) == 2
+
+        section, after = result.panels
+        assert section.grid.h == 1
+        assert section.panels == []
+        # Panel after empty section starts right after it (section footprint = 1)
+        assert after.grid.y == 1
+
+    def test_section_without_panels_key(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "No Panels Key"
+                panels:
+                  - title: "Bare Section"
+                    section:
+                      collapsed: true
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert len(result.panels) == 1
+        assert result.panels[0].type == "section"
+        assert result.panels[0].panels == []
+
+
+# ---------------------------------------------------------------------------
+# Section metadata
+# ---------------------------------------------------------------------------
+
+class TestSectionMetadata:
+    """Section grid info has correct IDs, titles, and types."""
+
+    def test_section_type_is_section(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Type Check"
+                panels:
+                  - title: "My Section"
+                    section:
+                      panels: []
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert result.panels[0].type == "section"
+
+    def test_section_with_explicit_id(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "ID Check"
+                panels:
+                  - id: "custom-section-id"
+                    title: "My Section"
+                    section:
+                      panels: []
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert result.panels[0].id == "custom-section-id"
+
+    def test_section_auto_id(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Auto ID"
+                panels:
+                  - title: "Health Metrics"
+                    section:
+                      panels: []
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert result.panels[0].id == "section_Health Metrics"
+
+    def test_section_width_is_full(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Width Check"
+                panels:
+                  - title: "Section"
+                    section:
+                      panels: []
+        """)
+        result = extract_grid_layout(yaml_path.as_posix())
+        assert result.panels[0].grid.w == 48
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+class TestErrorCases:
+    """Edge cases and error handling."""
+
+    def test_no_dashboards_raises(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards: []
+        """)
+        with pytest.raises(ValueError, match="No dashboards found"):
+            extract_grid_layout(yaml_path.as_posix())
+
+    def test_invalid_index_raises(self, tmp_path: Path) -> None:
+        yaml_path = _write_yaml(tmp_path, """
+            dashboards:
+              - name: "Only One"
+                panels:
+                  - title: "P"
+                    size: {w: 48, h: 4}
+                    markdown:
+                      content: "X"
+        """)
+        with pytest.raises(ValueError, match="out of range"):
+            extract_grid_layout(yaml_path.as_posix(), dashboard_index=5)

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/collapsible.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/collapsible.py
@@ -15,7 +15,15 @@ class SectionConfig(BaseCfgModel):
     """Whether the section is collapsed by default in Kibana."""
 
     panels: list[PanelTypes] = Field(default_factory=list)
-    """Panels contained within this collapsible section."""
+    """Panels contained within this collapsible section.
+
+    Inner panels use a **relative** coordinate space — their (x, y) positions
+    start at (0, 0) within the section body, independent of the section's
+    absolute position in the outer dashboard grid.
+
+    Nested CollapsiblePanels are not supported and will be rejected by the
+    Dashboard-level discriminator.
+    """
 
 
 class CollapsiblePanel(BasePanel):

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/compile.py
@@ -1,9 +1,15 @@
 """Compile Dashboard Panels to Kibana View Models."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from kb_dashboard_core.panels import ImagePanel, LinksPanel, MarkdownPanel, SearchPanel, VegaPanel
 from kb_dashboard_core.panels.auto_layout import LayoutAlgorithm, create_layout_engine
+
+if TYPE_CHECKING:
+    from kb_dashboard_core.panels.base import BasePanel
 from kb_dashboard_core.panels.charts.compile import compile_charts_panel_config
 from kb_dashboard_core.panels.charts.config import ESQLPanel, LensPanel
 from kb_dashboard_core.panels.charts.view import KbnLensPanel
@@ -127,17 +133,20 @@ def compile_dashboard_panel(panel: PanelTypes, grid: Grid) -> tuple[list[KbnRefe
 
 @log_compile
 def compute_panel_positions(
-    panels: Sequence[PanelTypes],
+    panels: Sequence['BasePanel'],
     algorithm: LayoutAlgorithm = 'up-left',
 ) -> dict[int, tuple[int, int]]:
     """Compute positions for panels that need auto-layout.
 
+    Only uses ``position`` and ``size`` attributes from BasePanel, so any panel
+    subclass (including CollapsiblePanel) can participate in the layout.
+
     Args:
-        panels (Sequence[PanelTypes]): The sequence of panel objects.
-        algorithm (LayoutAlgorithm): The layout algorithm to use. Defaults to 'up-left'.
+        panels: The sequence of panel objects (any BasePanel subclass).
+        algorithm: The layout algorithm to use. Defaults to 'up-left'.
 
     Returns:
-        dict[int, tuple[int, int]]: Mapping of panel index to (x, y) position.
+        Mapping of panel index to (x, y) position.
 
     """
     # Check if any panels need positioning

--- a/packages/vscode-extension/media/layoutEditor.js
+++ b/packages/vscode-extension/media/layoutEditor.js
@@ -62,7 +62,7 @@
         let maxY = 20;
         panels.forEach(panel => {
             if (panel.type === 'section' && panel.panels && panel.panels.length > 0) {
-                // Section height = header (1 row) + max inner panel bottom
+                // Section footprint = header (h=1) + max inner panel bottom
                 let innerMaxY = 0;
                 panel.panels.forEach(inner => {
                     const innerBottom = inner.grid.y + inner.grid.h;
@@ -70,7 +70,7 @@
                         innerMaxY = innerBottom;
                     }
                 });
-                const sectionBottom = panel.grid.y + 1 + innerMaxY;
+                const sectionBottom = panel.grid.y + panel.grid.h + innerMaxY;
                 if (sectionBottom > maxY) {
                     maxY = sectionBottom;
                 }

--- a/packages/vscode-extension/media/preview.css
+++ b/packages/vscode-extension/media/preview.css
@@ -424,6 +424,7 @@ code {
     border-bottom: 2px solid var(--vscode-focusBorder);
     border-radius: 0 0 3px 3px;
     box-sizing: border-box;
+    background: var(--vscode-editor-selectionBackground);
     background: color-mix(in srgb, var(--vscode-editor-selectionBackground) 30%, transparent);
 }
 

--- a/packages/vscode-extension/src/previewPanel.ts
+++ b/packages/vscode-extension/src/previewPanel.ts
@@ -476,19 +476,39 @@ export class PreviewPanel {
             }
 
             if (panel.type === 'section') {
-                // Calculate section total height: header (1 row) + inner panel content
-                let innerMaxY = 0;
+                // Section: h=1 header bar + inner panels rendered below it.
+                // The layout engine already reserved space for the full section footprint.
+                const headerHeight = panel.grid.h * PreviewPanel.scaleFactor;
+                let innerMaxBottom = 0;
+                let innerPanelsHtml = '';
+
                 if (panel.panels && panel.panels.length > 0) {
                     for (const inner of panel.panels) {
+                        const innerLeft = inner.grid.x * PreviewPanel.scaleFactor;
+                        const innerTop = inner.grid.y * PreviewPanel.scaleFactor;
+                        const innerWidth = inner.grid.w * PreviewPanel.scaleFactor;
+                        const innerHeight = inner.grid.h * PreviewPanel.scaleFactor;
                         const innerBottom = inner.grid.y + inner.grid.h;
-                        if (innerBottom > innerMaxY) {
-                            innerMaxY = innerBottom;
+                        if (innerBottom > innerMaxBottom) {
+                            innerMaxBottom = innerBottom;
                         }
+
+                        const chartInfo = PreviewPanel.chartTypeRegistry[inner.type];
+                        const icon = chartInfo ? chartInfo.icon : '';
+                        const label = chartInfo ? chartInfo.label : inner.type;
+
+                        innerPanelsHtml += `
+                            <div class="layout-panel section-inner-panel" style="left: ${innerLeft}px; top: ${innerTop}px; width: ${innerWidth}px; height: ${innerHeight}px;">
+                                <div class="panel-header">${escapeHtml(inner.title || 'Untitled')}</div>
+                                <div class="panel-type">${icon} ${escapeHtml(label)}</div>
+                                <div class="panel-size">w:${inner.grid.w} h:${inner.grid.h}</div>
+                            </div>
+                        `;
                     }
                 }
-                const sectionHeaderH = 1;
-                const sectionTotalH = sectionHeaderH + innerMaxY;
-                const panelBottom = panel.grid.y + sectionTotalH;
+
+                const totalHeight = headerHeight + (innerMaxBottom * PreviewPanel.scaleFactor);
+                const panelBottom = panel.grid.y + panel.grid.h + innerMaxBottom;
                 if (panelBottom > maxY) {
                     maxY = panelBottom;
                 }
@@ -496,27 +516,6 @@ export class PreviewPanel {
                 const left = panel.grid.x * PreviewPanel.scaleFactor;
                 const top = panel.grid.y * PreviewPanel.scaleFactor;
                 const width = panel.grid.w * PreviewPanel.scaleFactor;
-                const headerHeight = sectionHeaderH * PreviewPanel.scaleFactor;
-                const totalHeight = sectionTotalH * PreviewPanel.scaleFactor;
-
-                // Render inner panels within the section container
-                let innerPanelsHtml = '';
-                if (panel.panels && panel.panels.length > 0) {
-                    for (const inner of panel.panels) {
-                        const innerLeft = inner.grid.x * PreviewPanel.scaleFactor;
-                        const innerTop = inner.grid.y * PreviewPanel.scaleFactor;
-                        const innerWidth = inner.grid.w * PreviewPanel.scaleFactor;
-                        const innerHeight = inner.grid.h * PreviewPanel.scaleFactor;
-
-                        innerPanelsHtml += `
-                            <div class="layout-panel section-inner-panel" style="left: ${innerLeft}px; top: ${innerTop}px; width: ${innerWidth}px; height: ${innerHeight}px;">
-                                <div class="panel-header">${escapeHtml(inner.title || 'Untitled')}</div>
-                                <div class="panel-type">Type: ${escapeHtml(inner.type)}</div>
-                                <div class="panel-size">w:${inner.grid.w} h:${inner.grid.h}</div>
-                            </div>
-                        `;
-                    }
-                }
 
                 panelsHtml += `
                     <div class="section-container" data-panel-id="${escapeHtml(panel.id)}" data-index="${i}" style="left: ${left}px; top: ${top}px; width: ${width}px; height: ${totalHeight}px;">

--- a/packages/vscode-extension/src/schemas.generated.ts
+++ b/packages/vscode-extension/src/schemas.generated.ts
@@ -263,9 +263,15 @@ export type EsqlExecuteRequestType = z.infer<typeof EsqlExecuteRequest>;
 
 /**
  * Panel information including grid position.
- * Note: uses z.lazy() for recursive self-reference (section panels contain child panels).
- * Cannot use BaseLSPModel.extend() with z.ZodType annotation as strict mode
- * rejects the lazy field. Using z.object() directly instead.
+ *
+ * MANUALLY EDITED — pydantic2zod cannot generate this schema because:
+ * 1. The Pydantic model uses a recursive forward reference (list['PanelGridInfo'])
+ *    which pydantic2zod's parser doesn't support.
+ * 2. z.lazy() is required for the recursive `panels` field.
+ * 3. BaseLSPModel.extend().strict() rejects the lazy field, so we use z.object() directly
+ *    with an explicit z.ZodType<PanelGridInfoType> annotation.
+ *
+ * If regenerating schemas, this block must be preserved manually.
  */
 export type PanelGridInfoType = {
   id: string;


### PR DESCRIPTION
## Summary
- **Fix overlapping panels**: Sections now participate in auto-layout with height-inflated copies (header + inner content height), so panels after sections get correct Y positions. Output still emits `h=1` for section bars.
- **Widen `compute_panel_positions`**: Accept `Sequence[BasePanel]` instead of `Sequence[PanelTypes]` so CollapsiblePanels can participate in layout.
- **Render inner panels inline**: Section preview shows header bar + inner panels below it with correct relative coordinates.
- **Add 16 grid extractor tests**: Cover section layout flow, inner panel coordinates, empty sections, metadata, and error cases.
- **Document coordinate system**: Inner panels use relative coordinates (y=0 within section body), documented in docstrings.
- **CSS fallback**: Add solid color fallback before `color-mix()` for section body background.

## Test plan
- [x] 16 new grid extractor tests pass
- [x] 16 existing collapsible panel tests pass
- [x] TypeScript compiles clean
- [ ] Manual: Open dashboard with collapsible sections in preview, verify no overlap
- [ ] Manual: Verify inner panels render correctly inside section containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix section layout in preview panel to use `panel.grid.h` for header height
> - Section rendering in [`previewPanel.ts`](https://github.com/strawgate/kb-yaml-to-lens/pull/1197/files#diff-3035d6f5d32f63b8014399887e6c248003080cceb66036dc2067fe8b76ca83ad) now derives header height from `panel.grid.h` instead of a hardcoded value of 1, and computes total section height using the tallest inner panel's bottom edge.
> - [`_extract_inner_panels`](https://github.com/strawgate/kb-yaml-to-lens/pull/1197/files#diff-5e1d8925050ba9bde76ef78921801e86f50c62cc83f44151113c5c35c7946187) now returns a tuple of `(panels, max_bottom)` so callers can determine section footprint without re-iterating.
> - `extract_grid_layout` no longer raises `ValueError` for panels missing an explicit position when auto-layout fails; instead it appends the panel with a generated id.
> - Inner panel type display in the preview now shows an icon and human-friendly label via `chartTypeRegistry` instead of a plain `Type: <type>` string.
> - Adds unit tests for grid extraction covering basic layouts, section placement, inner panel coordinates, auto-layout, and error cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 60f96dd. 7 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented two-pass layout strategy for sections with improved content height calculation and inner panel positioning.
  * Added support for relative coordinate space within sections.

* **Bug Fixes**
  * Enhanced error messages for invalid layout configurations.

* **Documentation**
  * Clarified section configuration and inner panel behavior.

* **Tests**
  * Added comprehensive test suite for grid layout extraction and section handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->