### PR TITLE
feat: scope release-prep issues to last-tag diff

### DIFF
--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -49,12 +49,14 @@ gh label create "$LABEL" --repo "$REPO" --color "D4C5F9" --description "Pre-rele
 # Build reusable diff context for issue bodies
 if [ -n "$DIFF_RANGE" ]; then
     COMMIT_LOG=$(git log "$DIFF_RANGE" --oneline)
+    COMMIT_COUNT=$(git rev-list --count "$DIFF_RANGE")
     CHANGED_FILES=$(git diff --stat "$DIFF_RANGE" | tail -1)
     CHANGED_DOCS=$(git diff --name-only "$DIFF_RANGE" -- '*.md' 'RELEASE.md' 'DEVELOPING.md' 'CONTRIBUTING.md' || true)
+    RANGE_TEXT="since \`${LAST_TAG}\`"
 
     DIFF_CONTEXT_HEADER="### Scope
 
-This review covers changes between \`${LAST_TAG}\` and \`HEAD\` ($(echo "$COMMIT_LOG" | wc -l | tr -d ' ') commits, ${CHANGED_FILES}).
+This review covers changes between \`${LAST_TAG}\` and \`HEAD\` (${COMMIT_COUNT} commits, ${CHANGED_FILES}).
 
 <details>
 <summary>Commit log</summary>
@@ -67,6 +69,7 @@ ${COMMIT_LOG}
 else
     CHANGED_DOCS=""
     DIFF_CONTEXT_HEADER=""
+    RANGE_TEXT="for the full codebase (no previous tag)"
 fi
 
 # ============================================================================
@@ -77,13 +80,13 @@ echo "Creating issue: Documentation Review..."
 # Build doc-specific file list
 if [ -n "$CHANGED_DOCS" ]; then
     DOC_FILE_LIST=$(echo "$CHANGED_DOCS" | sed 's/^/- [ ] `/' | sed 's/$/`/')
-    DOC_SCOPE_NOTE="The following documentation files were modified since \`${LAST_TAG}\` and should be reviewed for accuracy:
+    DOC_SCOPE_NOTE="The following documentation files were modified ${RANGE_TEXT} and should be reviewed for accuracy:
 
 ${DOC_FILE_LIST}
 
 Also check that any new features introduced in this release are documented."
 else
-    DOC_SCOPE_NOTE="No documentation files were modified since \`${LAST_TAG}\`. Check that any new features introduced in this release have adequate documentation."
+    DOC_SCOPE_NOTE="No documentation files were modified ${RANGE_TEXT}. Check that any new features introduced in this release have adequate documentation."
 fi
 
 DOC_BODY="## Task
@@ -109,10 +112,10 @@ ${DOC_SCOPE_NOTE}
 
 \`\`\`bash
 # Docs modified since last release
-git diff --name-only ${LAST_TAG}..HEAD -- '*.md'
+git diff --name-only ${DIFF_RANGE:-HEAD} -- '*.md'
 
 # All commits touching docs
-git log ${LAST_TAG}..HEAD --oneline -- '*.md'
+git log ${DIFF_RANGE:-HEAD} --oneline -- '*.md'
 \`\`\`
 
 ### Definition of done
@@ -190,10 +193,10 @@ if [ -n "$DIFF_RANGE" ]; then
     QUALITY_FILE_CONTEXT="### Changed files to focus on
 
 \`\`\`bash
-# Python files changed since ${LAST_TAG}
+# Python files changed ${RANGE_TEXT}
 git diff --name-only ${DIFF_RANGE} -- '*.py'
 
-# TypeScript files changed since ${LAST_TAG}
+# TypeScript files changed ${RANGE_TEXT}
 git diff --name-only ${DIFF_RANGE} -- '*.ts' '*.tsx'
 
 # Full diff for review
@@ -203,7 +206,7 @@ fi
 
 QUALITY_BODY="## Task
 
-Scan code changed since \`${LAST_TAG}\` for code smells, dead code, and quality issues before the v${VERSION} release.
+Scan code changed ${RANGE_TEXT} for code smells, dead code, and quality issues before the v${VERSION} release.
 
 ${DIFF_CONTEXT_HEADER}
 
@@ -223,10 +226,10 @@ ${QUALITY_FILE_CONTEXT}
 
 \`\`\`bash
 # Find TODOs/FIXMEs in changed files
-git diff --name-only ${LAST_TAG}..HEAD -- '*.py' '*.ts' | xargs rg 'TODO|FIXME|HACK|XXX' || true
+git diff --name-only ${DIFF_RANGE:-HEAD} -- '*.py' '*.ts' | xargs rg 'TODO|FIXME|HACK|XXX' || true
 
 # Find type: ignore in changed Python files
-git diff --name-only ${LAST_TAG}..HEAD -- '*.py' | xargs rg 'type: ignore' || true
+git diff --name-only ${DIFF_RANGE:-HEAD} -- '*.py' | xargs rg 'type: ignore' || true
 
 # Run linters (full suite)
 just core lint
@@ -252,7 +255,7 @@ echo "Creating issue: Test Suite Review..."
 
 TEST_BODY="## Task
 
-Review the test suite for completeness and reliability before the v${VERSION} release, with focus on changes since \`${LAST_TAG}\`.
+Review the test suite for completeness and reliability before the v${VERSION} release, with focus on changes ${RANGE_TEXT}.
 
 ${DIFF_CONTEXT_HEADER}
 
@@ -268,14 +271,14 @@ ${DIFF_CONTEXT_HEADER}
 ### How to find what changed
 
 \`\`\`bash
-# Test files changed since ${LAST_TAG}
-git diff --name-only ${LAST_TAG}..HEAD -- '*test*' '*tests*'
+# Test files changed ${RANGE_TEXT}
+git diff --name-only ${DIFF_RANGE:-HEAD} -- '*test*' '*tests*'
 
 # Source files changed (check these have test coverage)
-git diff --name-only ${LAST_TAG}..HEAD -- '*.py' '*.ts' | grep -v test
+git diff --name-only ${DIFF_RANGE:-HEAD} -- '*.py' '*.ts' | grep -v test
 
 # Feature commits that should have tests
-git log ${LAST_TAG}..HEAD --oneline --grep='feat:'
+git log ${DIFF_RANGE:-HEAD} --oneline --grep='feat:'
 \`\`\`
 
 ### Commands
@@ -309,7 +312,7 @@ gh issue create --repo "$REPO" \
 echo "Creating issue: Release Notes Draft..."
 RELEASE_NOTES_BODY="## Task
 
-Draft release notes for v${VERSION} based on changes since \`${LAST_TAG}\`.
+Draft release notes for v${VERSION} based on changes ${RANGE_TEXT}.
 
 ${DIFF_CONTEXT_HEADER}
 
@@ -317,8 +320,8 @@ ${DIFF_CONTEXT_HEADER}
 
 1. Review commits since last tag:
    \`\`\`bash
-   git log ${LAST_TAG}..HEAD --oneline
-   git diff --stat ${LAST_TAG}..HEAD
+   git log ${DIFF_RANGE:-HEAD} --oneline
+   git diff --stat ${DIFF_RANGE:-HEAD}
    \`\`\`
 
 2. Categorize changes:


### PR DESCRIPTION
## Summary

- Release-prep script now auto-detects the last git tag and scopes all 5 issues to the `<last-tag>..HEAD` diff
- Each issue gets a collapsible commit log, changed file stats, and targeted git commands
- Documentation review lists only changed `.md` files instead of a hardcoded checklist
- Code quality scan and test review focus on changed files with `git diff --name-only | xargs` commands
- Falls back gracefully if no previous tag exists (first release)

## Test plan

- [ ] Run `bash -n scripts/release-prep.sh` to verify syntax
- [ ] Run `bash scripts/release-prep.sh 0.3.0` in a repo with tags and verify issue bodies contain diff context
- [ ] Verify fallback works when no tags exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope release-prep GitHub issues to the diff since the last git tag
> - [release-prep.sh](https://github.com/strawgate/kb-yaml-to-lens/pull/1204/files#diff-80a11a9fab82ac1a18742b86c3a4685275b4e7171498b23c355dc6a53ada8ad5) now detects the most recent git tag and computes a diff range (`LAST_TAG..HEAD`), printing the detected scope to the console.
> - Issue bodies for Documentation Review, Release Dry Run, Code Quality Scan, and Test Suite Review are dynamically composed to include commit logs, commit counts, and changed-file lists scoped to that diff range.
> - Documentation Review generates a list of changed docs from the diff rather than using a static checklist; Code Quality Scan and Test Suite Review include example commands targeting only files changed in the range.
> - If no previous tag exists, issue text falls back to indicating full-codebase scope.
> - Behavioral Change: issue bodies are now passed as string variables instead of heredoc with `sed` substitution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd66fb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release prep now detects the last tag and scopes a diff range (or falls back to full repo) for pre-release review.
  * Pre-release review items (docs, dry run, code quality, tests, release notes) include diff-aware context: commit count/log, changed files, and sample diffs.
  * Issue bodies and review commands updated to use dynamic, scoped review details across all pre-release checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->