### PR TITLE
fix(metric): persist line background charts via trendline layer wiring

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/compile.py
@@ -18,7 +18,11 @@ from kb_dashboard_core.panels.charts.gauge.compile import compile_esql_gauge_cha
 from kb_dashboard_core.panels.charts.gauge.config import ESQLGaugeChart, LensGaugeChart
 from kb_dashboard_core.panels.charts.heatmap.compile import compile_esql_heatmap_chart, compile_lens_heatmap_chart
 from kb_dashboard_core.panels.charts.heatmap.config import ESQLHeatmapChart, LensHeatmapChart
-from kb_dashboard_core.panels.charts.metric.compile import compile_esql_metric_chart, compile_lens_metric_chart
+from kb_dashboard_core.panels.charts.metric.compile import (
+    compile_esql_metric_chart,
+    compile_lens_metric_chart,
+    compile_lens_metric_trendline_layer_columns,
+)
 from kb_dashboard_core.panels.charts.metric.config import ESQLMetricChart, LensMetricChart
 from kb_dashboard_core.panels.charts.mosaic.compile import compile_esql_mosaic_chart, compile_lens_mosaic_chart
 from kb_dashboard_core.panels.charts.mosaic.config import ESQLMosaicChart, LensMosaicChart
@@ -137,6 +141,23 @@ def compile_lens_chart_state(  # noqa: PLR0912
                 layer_id, lens_columns_by_id, visualization_state = compile_lens_pie_chart(chart)
             case LensMetricChart():
                 layer_id, lens_columns_by_id, visualization_state = compile_lens_metric_chart(chart)
+                if visualization_state.trendlineLayerId is not None:
+                    trendline_columns, _trendline_time_accessor = compile_lens_metric_trendline_layer_columns(chart)
+                    form_based_datasource_state_layer_by_id[visualization_state.trendlineLayerId] = KbnFormBasedDataSourceStateLayer(
+                        columns=trendline_columns,
+                        columnOrder=list(trendline_columns.keys()),
+                        sampling=1,
+                        indexPatternId=chart.data_view,
+                        linkToLayers=[layer_id],
+                        ignoreGlobalFilters=False,
+                    )
+                    kbn_references.append(
+                        KbnReference(
+                            type='index-pattern',
+                            id=chart.data_view,
+                            name=f'indexpattern-datasource-layer-{visualization_state.trendlineLayerId}',
+                        )
+                    )
             case LensDatatableChart():
                 layer_id, lens_columns_by_id, visualization_state = compile_lens_datatable_chart(chart)
             case LensGaugeChart():

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/metric/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/metric/compile.py
@@ -17,6 +17,8 @@ from kb_dashboard_core.panels.charts.esql.columns.view import (
 )
 from kb_dashboard_core.panels.charts.lens.columns.view import (
     KbnLensColumnTypes,
+    KbnLensDateHistogramDimensionColumn,
+    KbnLensDateHistogramDimensionColumnParams,
 )
 from kb_dashboard_core.panels.charts.lens.dimensions.compile import compile_lens_dimension
 from kb_dashboard_core.panels.charts.lens.metrics.compile import compile_lens_metric
@@ -26,6 +28,7 @@ from kb_dashboard_core.panels.charts.metric.view import (
     KbnMetricVisualizationState,
     KbnSecondaryTrendNone,
 )
+from kb_dashboard_core.shared.config import stable_id_generator
 
 
 def compile_metric_chart_visualization_state(  # noqa: PLR0913
@@ -78,6 +81,18 @@ def compile_metric_chart_visualization_state(  # noqa: PLR0913
 
     palette = compile_color_range_mapping(chart.color) if isinstance(chart.color, ColorRangeMapping) else None
 
+    trendline_layer_id: str | None = None
+    trendline_time_accessor: str | None = None
+    trendline_metric_accessor: str | None = None
+    trendline_secondary_metric_accessor: str | None = None
+    trendline_layer_type: Literal['metricTrendline'] | None = None
+    if background_chart is not None and background_chart.type == 'line':
+        trendline_layer_id = stable_id_generator([layer_id, 'metric', 'trendline', 'layer'])
+        trendline_time_accessor = stable_id_generator([layer_id, 'metric', 'trendline', 'time'])
+        trendline_metric_accessor = primary_metric_id
+        trendline_secondary_metric_accessor = secondary_metric_id
+        trendline_layer_type = 'metricTrendline'
+
     return KbnMetricVisualizationState(
         layerId=layer_id,
         metricAccessor=primary_metric_id,
@@ -101,7 +116,48 @@ def compile_metric_chart_visualization_state(  # noqa: PLR0913
         secondaryAlign=secondary.alignment if secondary is not None else None,
         titleWeight=titles_and_text.weight if titles_and_text is not None else None,
         palette=palette,
+        trendlineLayerId=trendline_layer_id,
+        trendlineLayerType=trendline_layer_type,
+        trendlineTimeAccessor=trendline_time_accessor,
+        trendlineMetricAccessor=trendline_metric_accessor,
+        trendlineSecondaryMetricAccessor=trendline_secondary_metric_accessor,
     )
+
+
+def compile_lens_metric_trendline_layer_columns(
+    lens_metric_chart: LensMetricChart,
+) -> tuple[dict[str, KbnLensColumnTypes], str]:
+    """Compile columns for the metric trendline datasource layer."""
+    layer_id = lens_metric_chart.get_id()
+    trendline_time_accessor = stable_id_generator([layer_id, 'metric', 'trendline', 'time'])
+
+    trendline_columns: dict[str, KbnLensColumnTypes] = {
+        trendline_time_accessor: KbnLensDateHistogramDimensionColumn(
+            label='@timestamp',
+            dataType='date',
+            customLabel=False,
+            operationType='date_histogram',
+            sourceField='@timestamp',
+            isBucketed=True,
+            scale='interval',
+            params=KbnLensDateHistogramDimensionColumnParams(
+                interval='auto',
+                includeEmptyRows=True,
+                dropPartials=False,
+            ),
+        )
+    }
+
+    if lens_metric_chart.secondary is not None:
+        secondary_result = compile_lens_metric(lens_metric_chart.secondary)
+        trendline_columns[secondary_result.primary_id] = secondary_result.primary_column
+        trendline_columns.update(secondary_result.helper_columns)
+
+    primary_result = compile_lens_metric(lens_metric_chart.primary)
+    trendline_columns[primary_result.primary_id] = primary_result.primary_column
+    trendline_columns.update(primary_result.helper_columns)
+
+    return trendline_columns, trendline_time_accessor
 
 
 def compile_lens_metric_chart(

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/metric/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/metric/view.py
@@ -113,6 +113,21 @@ class KbnMetricVisualizationState(BaseVwModel):
     palette: Annotated[KbnRangePalette | None, OmitIfNone()] = Field(default=None)
     """Optional range-based palette settings for threshold coloring."""
 
+    trendlineLayerId: Annotated[str | None, OmitIfNone()] = Field(default=None)
+    """Layer ID for metric trendline data when line background chart is enabled."""
+
+    trendlineLayerType: Annotated[Literal['metricTrendline'] | None, OmitIfNone()] = Field(default=None)
+    """Layer type marker for metric trendline state."""
+
+    trendlineTimeAccessor: Annotated[str | None, OmitIfNone()] = Field(default=None)
+    """Accessor ID for trendline time dimension."""
+
+    trendlineMetricAccessor: Annotated[str | None, OmitIfNone()] = Field(default=None)
+    """Accessor ID for trendline primary metric."""
+
+    trendlineSecondaryMetricAccessor: Annotated[str | None, OmitIfNone()] = Field(default=None)
+    """Accessor ID for trendline secondary metric."""
+
 
 class KbnESQLMetricVisualizationState(BaseVwModel):
     """View model for ES|QL metric visualization state.

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/view.py
@@ -65,6 +65,8 @@ class KbnFormBasedDataSourceStateLayer(BaseVwModel):
     incompleteColumns: dict[str, Any] = Field(default_factory=dict)
     sampling: int
     indexPatternId: Annotated[str | None, OmitIfNone()] = None
+    linkToLayers: Annotated[list[str] | None, OmitIfNone()] = None
+    ignoreGlobalFilters: Annotated[bool | None, OmitIfNone()] = None
 
 
 class KbnFormBasedDataSourceStateLayerById(RootModel[dict[str, KbnFormBasedDataSourceStateLayer]]):

--- a/packages/kb-dashboard-core/tests/panels/charts/metric/test_metric.py
+++ b/packages/kb-dashboard-core/tests/panels/charts/metric/test_metric.py
@@ -731,6 +731,25 @@ def test_compile_metric_chart_background_chart_type_mapping(chart_type: str, bac
         assert result['showBar'] is expected_show_bar
 
 
+def test_compile_metric_chart_line_background_adds_trendline_fields_lens() -> None:
+    """Test line background charts emit trendline accessors in visualization state."""
+    config = {
+        'type': 'metric',
+        'data_view': 'metrics-*',
+        'primary': {'aggregation': 'count', 'id': 'primary-metric'},
+        'secondary': {'aggregation': 'count', 'id': 'secondary-metric'},
+        'appearance': {'primary': {'background_chart': {'type': 'line'}}},
+    }
+
+    result = compile_metric_chart_snapshot(config, 'lens')
+    assert result['showBar'] is False
+    assert result['trendlineLayerType'] == 'metricTrendline'
+    assert result['trendlineLayerId']
+    assert result['trendlineTimeAccessor']
+    assert result['trendlineMetricAccessor'] == 'primary-metric'
+    assert result['trendlineSecondaryMetricAccessor'] == 'secondary-metric'
+
+
 @pytest.mark.parametrize('chart_type', ['lens', 'esql'])
 @pytest.mark.parametrize('direction', ['horizontal', 'vertical'])
 def test_compile_metric_chart_background_chart_bar_direction(chart_type: str, direction: str) -> None:
@@ -1063,6 +1082,42 @@ def test_metric_chart_dashboard_references_bubble_up() -> None:
             }
         ]
     )
+
+
+def test_metric_line_background_adds_trendline_reference_and_layer() -> None:
+    """Test line background charts include trendline datasource layer and reference."""
+    dashboard = Dashboard(
+        name='Line Trendline Metric Dashboard',
+        panels=[
+            {
+                'title': 'Metric Line',
+                'id': 'metric-panel-line',
+                'position': {'x': 0, 'y': 0},
+                'size': {'w': 12, 'h': 8},
+                'lens': {
+                    'type': 'metric',
+                    'data_view': 'metrics-*',
+                    'primary': {'aggregation': 'count', 'id': 'primary-metric'},
+                    'secondary': {'aggregation': 'count', 'id': 'secondary-metric'},
+                    'appearance': {'primary': {'background_chart': {'type': 'line'}}},
+                },
+            }
+        ],
+    )
+
+    kbn_dashboard: KbnDashboard = render(dashboard=dashboard)
+    references = [ref.model_dump() for ref in kbn_dashboard.references]
+    assert len(references) == 2
+    assert all(ref['type'] == 'index-pattern' and ref['id'] == 'metrics-*' for ref in references)
+    assert all(ref['name'].startswith('metric-panel-line:indexpattern-datasource-layer-') for ref in references)
+
+    panel_json = kbn_dashboard.attributes.panelsJSON[0].model_dump()
+    layers = panel_json['embeddableConfig']['attributes']['state']['datasourceStates']['formBased']['layers']
+    assert len(layers) == 2
+    panel_layer_id = panel_json['embeddableConfig']['attributes']['state']['visualization']['layerId']
+    trendline_layer = next(layer for layer in layers.values() if layer.get('linkToLayers') == [panel_layer_id])
+    assert trendline_layer['indexPatternId'] == 'metrics-*'
+    assert trendline_layer['ignoreGlobalFilters'] is False
 
 
 def test_compile_metric_chart_with_maximum_lens() -> None:


### PR DESCRIPTION
## Summary
- emit metric trendline visualization keys (`trendlineLayerId`, `trendlineLayerType`, and trendline accessors) when `appearance.primary.background_chart.type` is `line`
- compile a linked form-based trendline datasource layer with `@timestamp` date histogram and metric columns so Kibana persists line mode consistently
- extend metric tests to cover trendline visualization state and datasource/reference wiring for line background charts

## Test plan
- [x] `uv run pytest tests/panels/charts/metric/test_metric.py -q`
- [x] `uv run ruff check packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/compile.py packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/metric/compile.py packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/metric/view.py packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/view.py packages/kb-dashboard-core/tests/panels/charts/metric/test_metric.py`
- [x] `uv run --group dev basedpyright packages/kb-dashboard-core`

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix line background charts in Lens metric panels by wiring trendline layer compilation
> - Adds `compile_lens_metric_trendline_layer_columns` in [`metric/compile.py`](https://github.com/strawgate/kb-yaml-to-lens/pull/1298/files#diff-435fc7f365094304b64a594240dc3c66724df5b69eeccaa3e2c32fa737581268) to build a date-histogram-based trendline layer with primary and secondary metric columns.
> - Updates [`compile.py`](https://github.com/strawgate/kb-yaml-to-lens/pull/1298/files#diff-28dda3657257aa0f4fbda3a5e3c956797fbb14bc517b7b021c83724a301b0f51) to inject the trendline datasource layer and an extra `index-pattern` reference into the panel JSON when `trendlineLayerId` is set on the visualization state.
> - Extends `KbnMetricVisualizationState` with optional trendline fields (`trendlineLayerId`, `trendlineLayerType`, `trendlineTimeAccessor`, etc.) and `KbnFormBasedDataSourceStateLayer` with `linkToLayers` and `ignoreGlobalFilters`.
> - Behavioral Change: Lens metric charts with a line background now emit a second datasource layer linked to the primary layer; previously this layer was absent, causing the background chart not to render.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 447c56a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trendline visualization support for metric charts with line backgrounds. Metric visualizations now automatically display trend lines when configured with a line chart background, with proper data layer management and accessor configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->