### PR TITLE
fix: add setup-commands to AI workflows, remove just guards

### DIFF
--- a/.github/workflows/address-pr-review-feedback.yml
+++ b/.github/workflows/address-pr-review-feedback.yml
@@ -21,6 +21,7 @@ jobs:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review-addresser.lock.yml@main
     with:
       allowed-bot-users: coderabbitai[bot],github-actions[bot]
+      setup-commands: make install-just && uv sync
       additional-instructions: |
         Focus on minor and straightforward fixes only. Address feedback that involves:
         - Typos, naming, and formatting issues

--- a/.github/workflows/explore-content-panels.yml
+++ b/.github/workflows/explore-content-panels.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-content-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-esql.yml
+++ b/.github/workflows/explore-esql.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-esql-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-datatable.yml
+++ b/.github/workflows/explore-lens-datatable.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-datatable-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-gauge.yml
+++ b/.github/workflows/explore-lens-gauge.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-gauge-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-heatmap.yml
+++ b/.github/workflows/explore-lens-heatmap.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-heatmap-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-metric.yml
+++ b/.github/workflows/explore-lens-metric.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-metric-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-partition.yml
+++ b/.github/workflows/explore-lens-partition.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-partition-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-pie.yml
+++ b/.github/workflows/explore-lens-pie.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-pie-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-tagcloud.yml
+++ b/.github/workflows/explore-lens-tagcloud.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-tagcloud-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}

--- a/.github/workflows/explore-lens-xy.yml
+++ b/.github/workflows/explore-lens-xy.yml
@@ -44,7 +44,7 @@ jobs:
     with:
       title-prefix: '[explore-lens-xy-${{ matrix.kibana_version }}]'
       setup-commands: |
-        command -v just >/dev/null 2>&1 || make install-just
+        make install-just
         uv sync
         npx playwright install chromium
         just explore-bootstrap ${{ matrix.kibana_version }}


### PR DESCRIPTION
## Summary
- Add `make install-just && uv sync` to `address-pr-review-feedback` workflow — it can modify code (fix lint/type/test errors) but was missing setup, so `just` and Python deps were unavailable
- Remove `command -v just >/dev/null 2>&1 ||` guards from 10 `explore-*` workflows — `just` is not pre-installed on the runners, the guard just masked install failures

## Files changed
- `address-pr-review-feedback.yml` — added `setup-commands`
- 10x `explore-*.yml` — `command -v just || make install-just` → `make install-just`

## Test plan
- [ ] All workflows still trigger correctly
- [ ] `address-pr-review-feedback` can now run `just lint` and `just test` when fixing CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace conditional `just` checks with unconditional `make install-just` in AI workflows
> - Removes the `command -v just >/dev/null 2>&1 || make install-just` guard from all `explore-*` AI workflows, replacing it with an unconditional `make install-just` call.
> - Adds a `setup-commands` input (`make install-just && uv sync`) to the `address-pr-review-feedback` workflow, which previously had none.
> - Behavioral Change: `make install-just` now always runs during setup regardless of whether `just` is already present on the runner.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e16b0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized setup commands across multiple CI/CD workflows to ensure consistent installation of required build tools during pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->