### PR TITLE
feat(workflows): /explore triggers both 8.19 and 9.3 agents

### DIFF
--- a/.github/workflows/explore-kibana-saved-objects-8.yml
+++ b/.github/workflows/explore-kibana-saved-objects-8.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   run:
-    if: startsWith(github.event.comment.body, '/explore8') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    if: (startsWith(github.event.comment.body, '/explore8') || startsWith(github.event.comment.body, '/explore ') || github.event.comment.body == '/explore') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
       title-prefix: '[explore-kibana-saved-objects-8.19]'


### PR DESCRIPTION
## Summary
- `/explore` and `/explore <spec>` now trigger both Kibana 8.19.0 and 9.3.0 agents in parallel
- `/explore8` and `/explore9` remain version-specific overrides
- Concurrency groups are already separate so the two agents won't cancel each other

## Test plan
- [ ] `/explore` on an issue triggers both workflows
- [ ] `/explore8` triggers only the 8.19 workflow
- [ ] `/explore9` triggers only the 9.3 workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger explore workflow for both 8.19 and 9.3 agents with `/explore` comment
> Updates the `if` condition in [explore-kibana-saved-objects-8.yml](https://github.com/strawgate/kb-yaml-to-lens/pull/1354/files#diff-f77dade91ccfe7c77bc311d952818f0ab2561421e410f9ac2c5fac812729538e) so the `run` job fires when a comment equals `/explore`, starts with `/explore ` (space), or starts with `/explore8`. Previously only `/explore8` triggered this workflow, so `/explore` now fans out to both the 8.19 and 9.3 agent workflows simultaneously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9937574.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow triggering to accept multiple command formats for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->