### PR TITLE
fix(bootstrap): use host networking for ES and Kibana containers

### DIFF
--- a/scripts/bootstrap-explore-kibana.sh
+++ b/scripts/bootstrap-explore-kibana.sh
@@ -11,29 +11,27 @@
 set -euo pipefail
 
 KIBANA_VERSION="${1:-9.3.0}"
-NETWORK_NAME="explore-net"
 ES_CONTAINER="es-explore"
 KIBANA_CONTAINER="kibana-explore"
 
 echo "Bootstrapping Elasticsearch + Kibana (version: ${KIBANA_VERSION})"
 
 docker rm -f "${ES_CONTAINER}" "${KIBANA_CONTAINER}" >/dev/null 2>&1 || true
-docker network rm "${NETWORK_NAME}" >/dev/null 2>&1 || true
-docker network create "${NETWORK_NAME}" >/dev/null
 
+# Use host networking so ES and Kibana bind directly to the host's interfaces.
+# This is required for the AWF sandbox — the agent container can only reach the
+# host via host.docker.internal, and the AWF firewall blocks non-standard ports
+# when containers use bridge networking with -p port mappings.
 docker run -d --name "${ES_CONTAINER}" \
-  --network "${NETWORK_NAME}" \
-  -p 9200:9200 \
+  --network host \
   -e "discovery.type=single-node" \
   -e "xpack.security.enabled=false" \
   -e "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
-  -e "network.host=0.0.0.0" \
   "docker.elastic.co/elasticsearch/elasticsearch:${KIBANA_VERSION}" >/dev/null
 
 docker run -d --name "${KIBANA_CONTAINER}" \
-  --network "${NETWORK_NAME}" \
-  -p 5601:5601 \
-  -e "ELASTICSEARCH_HOSTS=http://${ES_CONTAINER}:9200" \
+  --network host \
+  -e "ELASTICSEARCH_HOSTS=http://localhost:9200" \
   -e "XPACK_SECURITY_ENABLED=false" \
   -e "SERVER_HOST=0.0.0.0" \
   "docker.elastic.co/kibana/kibana:${KIBANA_VERSION}" >/dev/null


### PR DESCRIPTION
## Summary
- Switch ES and Kibana containers from bridge networking (`explore-net` with `-p` port mappings) to `--network host`
- The AWF sandbox firewall only forwards ports 80/443 through its Squid proxy and drops all other outbound TCP — making `host.docker.internal:5601` and `:9200` unreachable from agent shell commands
- Host networking matches how the MCP gateway and Playwright containers are already configured, and eliminates the need for a custom Docker network and port mappings

## Test plan
- [ ] Trigger an `/explore` run on this PR to verify the agent can reach Kibana via `host.docker.internal:5601` from shell commands
- [ ] Verify `uv run kb-dashboard compile --upload --kibana-url http://host.docker.internal:5601` succeeds
- [ ] Verify Playwright can still reach `http://localhost:5601`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Restructured container networking configuration to use host networking mode instead of custom docker networks for improved simplicity.
- Updated Elasticsearch and Kibana service connectivity to use localhost addressing.
- Streamlined network configuration in the bootstrap process.

**Chores**
- Removed explicit docker network management operations.
- Simplified container startup procedures for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->