### PR TITLE
fix(justfiles): use source_directory() instead of justfile_directory()

### DIFF
--- a/packages/kb-dashboard-cli/justfile
+++ b/packages/kb-dashboard-cli/justfile
@@ -4,8 +4,9 @@
 # Import shared helpers
 import '../../shared.just'
 
-# Repository root (parent of packages directory)
-REPO_ROOT := justfile_directory() / "../.."
+# Repository root — use source_directory() so this resolves correctly both
+# when invoked directly (just typecheck) and via root mod (just core typecheck).
+REPO_ROOT := source_directory() / "../.."
 
 # Docker configuration
 DOCKER_IMAGE_NAME := "kb-dashboard-compiler"
@@ -199,7 +200,7 @@ docker-run:
     @mkdir -p inputs ../output
     @echo "Note: Mount your inputs directory with -v /path/to/inputs:/inputs"
     just _print-start "Running Docker container"
-    docker run --rm -v "{{justfile_directory()}}/inputs:/inputs" -v "{{justfile_directory()}}/../output:/output" {{DOCKER_IMAGE}} compile --input-dir /inputs --output-dir /output
+    docker run --rm -v "{{source_directory()}}/inputs:/inputs" -v "{{source_directory()}}/../output:/output" {{DOCKER_IMAGE}} compile --input-dir /inputs --output-dir /output
     just _print-end "Docker container completed"
 
 docker-test:

--- a/packages/kb-dashboard-core/justfile
+++ b/packages/kb-dashboard-core/justfile
@@ -4,8 +4,9 @@
 # Import shared helpers
 import '../../shared.just'
 
-# Repository root (parent of packages directory)
-REPO_ROOT := justfile_directory() / "../.."
+# Repository root — use source_directory() so this resolves correctly both
+# when invoked directly (just typecheck) and via root mod (just core typecheck).
+REPO_ROOT := source_directory() / "../.."
 
 # Default recipe - show help
 default:

--- a/packages/kb-dashboard-docs/justfile
+++ b/packages/kb-dashboard-docs/justfile
@@ -8,8 +8,8 @@ import '../../shared.just'
 REPO_ROOT := `git rev-parse --show-toplevel`
 
 # Paths
-DOCS_CONTENT_DIR := justfile_directory() / "content"
-RESOURCES_DIR := justfile_directory() / "src/kb_dashboard_docs/resources"
+DOCS_CONTENT_DIR := source_directory() / "content"
+RESOURCES_DIR := source_directory() / "src/kb_dashboard_docs/resources"
 
 # Default recipe - show help
 default:

--- a/packages/kb-dashboard-lint/justfile
+++ b/packages/kb-dashboard-lint/justfile
@@ -4,8 +4,9 @@
 # Import shared helpers
 import '../../shared.just'
 
-# Repository root (parent of packages directory)
-REPO_ROOT := justfile_directory() / "../.."
+# Repository root — use source_directory() so this resolves correctly both
+# when invoked directly and via root mod (just lint ...).
+REPO_ROOT := source_directory() / "../.."
 
 # Default recipe - show help
 default:

--- a/packages/kb-dashboard-tools/justfile
+++ b/packages/kb-dashboard-tools/justfile
@@ -4,8 +4,9 @@
 # Import shared helpers
 import '../../shared.just'
 
-# Repository root (parent of packages directory)
-REPO_ROOT := justfile_directory() / "../.."
+# Repository root — use source_directory() so this resolves correctly both
+# when invoked directly and via root mod (just tools ...).
+REPO_ROOT := source_directory() / "../.."
 
 # Default recipe - show help
 default:


### PR DESCRIPTION
## Summary
- Replace `justfile_directory()` with `source_directory()` in all 5 package justfiles
- Fixes `REPO_ROOT` resolving to the wrong directory when commands are invoked via the root `mod` system (e.g. `just core typecheck`)

## Root cause
`justfile_directory()` returns the directory of the **importing** justfile when used in a `mod`-imported file. So `just core typecheck` resolves `REPO_ROOT` to `<repo>/../..` instead of `<repo>`. `source_directory()` always returns the directory of the file it appears in, regardless of how it was imported.

This didn't break CI because CI uses `just all typecheck` which calls `just --justfile "$component/justfile"` directly. But it broke local `just core typecheck` and any agent worktree usage.

## Test plan
- [ ] `just core typecheck` resolves paths correctly
- [ ] `just all typecheck` still works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script path resolution across multiple packages to improve compatibility when scripts are invoked in different contexts. These changes ensure consistent and correct directory references in automation workflows without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->