### PR TITLE
fix(tools): surface Kibana missing_references errors instead of "Unknown error"

### DIFF
--- a/packages/kb-dashboard-tools/src/kb_dashboard_tools/kibana_client.py
+++ b/packages/kb-dashboard-tools/src/kb_dashboard_tools/kibana_client.py
@@ -25,6 +25,17 @@ HTTP_SERVICE_UNAVAILABLE = 503
 # ============================================================================
 
 
+class MissingReference(BaseModel):
+    """A missing reference reported by Kibana's saved objects import API."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra='allow')
+
+    type: str
+    """Reference type, e.g. 'index-pattern'."""
+    id: str
+    """Reference ID that could not be resolved."""
+
+
 class KibanaErrorDetail(BaseModel):
     """Structured error detail from Kibana API responses.
 
@@ -38,6 +49,8 @@ class KibanaErrorDetail(BaseModel):
     """Error message from Kibana."""
     type: str | None = None
     """Error type identifier."""
+    references: list[MissingReference] = Field(default_factory=list)
+    """Missing references (populated when type is 'missing_references')."""
 
 
 # ============================================================================
@@ -156,8 +169,14 @@ class SavedObjectError(BaseModel):
             Error message from nested error detail, top-level message, or 'Unknown error'.
 
         """
-        if self.error is not None and self.error.message is not None:
-            return self.error.message
+        if self.error is not None:
+            if self.error.type == 'missing_references' and self.error.references:
+                refs = ', '.join(f'{r.type}:{r.id}' for r in self.error.references)
+                return f'Missing references: {refs}'
+            if self.error.message is not None:
+                return self.error.message
+            if self.error.type is not None:
+                return f'Error type: {self.error.type}'
         if self.message is not None:
             return self.message
         return 'Unknown error'


### PR DESCRIPTION
## Summary
- Add `MissingReference` model and `references` field to `KibanaErrorDetail`
- Update `get_error_message()` to produce descriptive messages for `missing_references` errors (e.g. `Missing references: index-pattern:logs-*`)
- Fall back to `error.type` when no `message` field is present

## Context
When Kibana's import API returns `{"error": {"type": "missing_references", "references": [...]}}`, the CLI showed only "Unknown error" because the error model didn't parse the `references` array and `get_error_message()` only looked for a `message` field.

Closes #1386

## Test plan
- [ ] All existing tests pass
- [ ] Upload to a Kibana instance where data view doesn't exist shows `Missing references: index-pattern:logs-*` instead of `Unknown error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling for Kibana saved objects import with detailed reporting of unresolved references, displaying reference types and IDs in error messages.

* **Bug Fixes**
  * Enhanced error message extraction to provide clearer feedback when references cannot be resolved during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->