### PR TITLE
docs: restore collapse field in ESQL dimension docs

### DIFF
--- a/packages/kb-dashboard-docs/content/panels/esql.md
+++ b/packages/kb-dashboard-docs/content/panels/esql.md
@@ -447,6 +447,7 @@ Used to specify a dimension/grouping column from your ESQL query result.
 | `field` | `string` | The name of the column in your ESQL query result that represents the dimension. | N/A | Yes |
 | `label` | `string` | An optional display label for the dimension. If not provided, the field name is used. | `None` | No |
 | `data_type` | `Literal['date'] \| None` | The data type of the field. Set to `'date'` for time/date fields to enable proper sorting and formatting in Kibana. This is particularly useful when using `BUCKET()` to create time series. | `None` | No |
+| `collapse` | `CollapseAggregationEnum \| None` | The collapse function to apply to this dimension (`sum`, `avg`, `min`, `max`). Used to aggregate values when multiple series exist. | `None` | No |
 
 **Example using label and data_type for time series:**
 


### PR DESCRIPTION
## Summary
- Restore the `collapse` row in the ESQL Dimension Column reference table in `esql.md`
- PR #1368 removed it from the docs but `ESQLDimension` still has the `collapse` field in code (`esql/columns/config.py:68`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `collapse` field to ESQL Dimension Column definitions, enabling aggregation of dimension values using sum, avg, min, and max operations when working with multiple data series.

* **Documentation**
  * Updated ESQL panel documentation with comprehensive details on the new `collapse` parameter, including usage guidelines and practical configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->