### PR TITLE
scripts: set bootstrap data view id to title

### DIFF
--- a/scripts/bootstrap-explore-kibana.sh
+++ b/scripts/bootstrap-explore-kibana.sh
@@ -138,7 +138,7 @@ for DV in "logs-*" "metrics-*"; do
   curl -fsS -X POST "http://localhost:443/api/data_views/data_view" \
     -H "kbn-xsrf: true" \
     -H "Content-Type: application/json" \
-    -d "{\"data_view\":{\"title\":\"${DV}\",\"name\":\"${DV}\",\"timeFieldName\":\"@timestamp\"}}" \
+    -d "{\"data_view\":{\"id\":\"${DV}\",\"title\":\"${DV}\",\"name\":\"${DV}\",\"timeFieldName\":\"@timestamp\"}}" \
     >/dev/null
   echo "  Created data view: ${DV}"
 done


### PR DESCRIPTION
## Summary
- update Kibana explore bootstrap data-view creation payload to set data_view.id explicitly
- set id equal to the existing title/name value (logs-* and metrics-*)

## Validation
- bash -n scripts/bootstrap-explore-kibana.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data view creation process to include required identifiers during initialization, ensuring proper setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->