### PR TITLE
Fix stale schema key references in explore workflows

### DIFF
--- a/.github/workflows/explore-esql-datatable.yml
+++ b/.github/workflows/explore-esql-datatable.yml
@@ -72,7 +72,7 @@ jobs:
         ### Config slots
         - **metrics** (optional) — metric columns
         - **dimensions** (optional) — row grouping columns
-        - **dimensions_by** (optional) — split metrics by dimension values
+        - **metrics_split_by** (optional) — split metrics by breakdown values
         - At least one metric OR dimension is required
 
         ### Per-column appearance (metrics and dimensions)

--- a/.github/workflows/explore-esql-heatmap.yml
+++ b/.github/workflows/explore-esql-heatmap.yml
@@ -76,11 +76,11 @@ jobs:
         - **value** (required) — cell color intensity metric
 
         ### Grid configuration (`grid_config:`)
-        - `cells.show_labels` — show value labels in cells (boolean)
-        - `x_axis.show_labels` — show x-axis labels (boolean)
-        - `x_axis.show_title` — show x-axis title (boolean)
-        - `y_axis.show_labels` — show y-axis labels (boolean)
-        - `y_axis.show_title` — show y-axis title (boolean)
+        - `values.visible` — show value labels in cells (boolean)
+        - `x_axis.labels.visible` — show x-axis labels (boolean)
+        - `x_axis.title.visible` — show x-axis title (boolean)
+        - `y_axis.labels.visible` — show y-axis labels (boolean)
+        - `y_axis.title.visible` — show y-axis title (boolean)
 
         ### Legend (`legend:`)
         - `visible` — `show` or `hide` (NOTE: heatmap does NOT support `auto`)

--- a/.github/workflows/explore-esql-metric.yml
+++ b/.github/workflows/explore-esql-metric.yml
@@ -83,8 +83,8 @@ jobs:
 
         ### Appearance (`appearance:`)
         - `apply_to` — color target: `value` or `background` (default: `background`)
-        - `title_position` — `top` or `bottom`
-        - `value_font_size` — `default`, `xs`, `s`, `m`, `l`, `xl`, `xxl`
+        - `primary.position` — `top` or `bottom`
+        - `primary.font_size` — `default`, `xs`, `s`, `m`, `l`, `xl`, `xxl`
 
         ### Color (`color:`)
         - `palette` — categorical or range color palette
@@ -96,8 +96,8 @@ jobs:
         ### Titles and text (`titles_and_text:`)
         - `prefix` — text before the value
         - `suffix` — text after the value
-        - `secondary_prefix` — text before secondary metric
-        - `secondary_suffix` — text after secondary metric
+        - `secondary.format.prefix` — text before secondary metric
+        - `secondary.format.suffix` — text after secondary metric
 
         ## Creative exploration
         - ES|QL metric with `STATS count = COUNT()` as primary

--- a/.github/workflows/explore-esql-partition.yml
+++ b/.github/workflows/explore-esql-partition.yml
@@ -78,8 +78,8 @@ jobs:
         - `color.assignments` — manual value-to-color mappings
         - `legend` — `visible`, `position`, `width`, `truncate_labels`, `nested`,
           `show_single_series`
-        - `titles_and_text.value_format` — `percent`, `value`, `hidden`
-        - `titles_and_text.value_decimal_places` — 0-10
+        - `appearance.values.format` — `percent`, `value`, `hidden`
+        - `appearance.values.decimal_places` — 0-10
         **Known Kibana limitations for Waffle:**
         - Waffle does NOT have a Maximum value slot (unlike Metric)
         - Waffle does NOT have a Breakdown slot — using `breakdown` may
@@ -92,8 +92,8 @@ jobs:
         - `color.palette` — categorical color palette
         - `color.assignments` — manual value-to-color mappings
         - `legend` — same options as waffle
-        - `titles_and_text.value_format` — `percent`, `value`, `hidden`
-        - `titles_and_text.value_decimal_places` — 0-10
+        - `appearance.values.format` — `percent`, `value`, `hidden`
+        - `appearance.values.decimal_places` — 0-10
 
         ## Creative exploration
         - ES|QL waffle with `STATS count = COUNT() BY status`

--- a/.github/workflows/explore-lens-heatmap.yml
+++ b/.github/workflows/explore-lens-heatmap.yml
@@ -64,11 +64,11 @@ jobs:
         - **value** (required) — cell color intensity metric
 
         ### Grid configuration (`grid_config:`)
-        - `cells.show_labels` — show value labels in cells (boolean)
-        - `x_axis.show_labels` — show x-axis labels (boolean)
-        - `x_axis.show_title` — show x-axis title (boolean)
-        - `y_axis.show_labels` — show y-axis labels (boolean)
-        - `y_axis.show_title` — show y-axis title (boolean)
+        - `values.visible` — show value labels in cells (boolean)
+        - `x_axis.labels.visible` — show x-axis labels (boolean)
+        - `x_axis.title.visible` — show x-axis title (boolean)
+        - `y_axis.labels.visible` — show y-axis labels (boolean)
+        - `y_axis.title.visible` — show y-axis title (boolean)
 
         ### Legend (`legend:`)
         - `visible` — `show` or `hide` (NOTE: heatmap does NOT support `auto`)

--- a/.github/workflows/explore-lens-metric.yml
+++ b/.github/workflows/explore-lens-metric.yml
@@ -108,7 +108,7 @@ jobs:
         - Dynamic coloring with color range stops
 
         ### Dimension types for breakdown
-        - `type: values` — top values / terms with `field`, `size`, `other_bucket`
+        - `type: values` — top values / terms with `field`, `size`, `show_other_bucket`
         - `type: date_histogram` — with `minimum_interval`
         - `type: intervals` — numeric ranges
         - `type: filters` — KQL filter-based dimension

--- a/.github/workflows/explore-lens-partition.yml
+++ b/.github/workflows/explore-lens-partition.yml
@@ -66,8 +66,8 @@ jobs:
         - `color.assignments` — manual value-to-color mappings
         - `legend` — `visible`, `position`, `width`, `truncate_labels`, `nested`,
           `show_single_series`
-        - `titles_and_text.value_format` — `percent`, `value`, `hidden`
-        - `titles_and_text.value_decimal_places` — 0-10
+        - `appearance.values.format` — `percent`, `value`, `hidden`
+        - `appearance.values.decimal_places` — 0-10
         **Known Kibana limitations for Waffle:**
         - Waffle does NOT have a Maximum value slot (unlike Metric)
         - Waffle does NOT have a Breakdown slot — using `breakdown` in YAML may
@@ -81,11 +81,11 @@ jobs:
         - `color.palette` — categorical color palette
         - `color.assignments` — manual value-to-color mappings
         - `legend` — same options as waffle
-        - `titles_and_text.value_format` — `percent`, `value`, `hidden`
-        - `titles_and_text.value_decimal_places` — 0-10
+        - `appearance.values.format` — `percent`, `value`, `hidden`
+        - `appearance.values.decimal_places` — 0-10
 
         ### Shared dimension types
-        - `type: values` — top values with `field`, `size`, `other_bucket`
+        - `type: values` — top values with `field`, `size`, `show_other_bucket`
         - `type: date_histogram` — time bucketing
         - `type: intervals` — numeric ranges
         - `type: filters` — KQL filter-based

--- a/.github/workflows/explore-lens-pie.yml
+++ b/.github/workflows/explore-lens-pie.yml
@@ -67,8 +67,8 @@ jobs:
         - Donut — `appearance.donut: small` (0.3), `medium` (0.5), `large` (0.7)
 
         ### Dimension types (`dimensions:`)
-        - `type: values` — top values/terms with `field`, `size`, `other_bucket`,
-          `missing_bucket`, `include`/`exclude`
+        - `type: values` — top values/terms with `field`, `size`, `show_other_bucket`,
+          `include_missing_values`, `include`/`exclude`
         - `type: date_histogram` — with `field`, `minimum_interval`
         - `type: intervals` — numeric ranges
         - `type: filters` — KQL filter-based
@@ -101,7 +101,7 @@ jobs:
         - Donut with 2 nested ring dimensions + custom color assignments
         - Pie with filters dimension (e.g. error vs warning vs info)
         - Large donut with `slice_labels: inside` + `slice_values: percent`
-        - Pie with `other_bucket: true` + small `size` to show grouping
+        - Pie with `show_other_bucket: true` + small `size` to show grouping
         - Multiple metrics on a single pie (test emptySizeRatio behavior)
         - Formula-based metric as pie slice size
         - Pie chart inside a collapsible section

--- a/.github/workflows/explore-lens-tagcloud.yml
+++ b/.github/workflows/explore-lens-tagcloud.yml
@@ -63,8 +63,8 @@ jobs:
         - **metric** (required) — determines tag size
 
         ### Dimension types
-        - `type: values` — top values/terms with `field`, `size`, `other_bucket`,
-          `missing_bucket`, `include`/`exclude` (regex support), `collapse`
+        - `type: values` — top values/terms with `field`, `size`, `show_other_bucket`,
+          `include_missing_values`, `include`/`exclude` (regex support), `collapse`
         - `type: date_histogram` — with `field`, `minimum_interval`,
           `partial_intervals`
         - `type: intervals` — numeric ranges with `granularity`

--- a/.github/workflows/explore-lens-xy.yml
+++ b/.github/workflows/explore-lens-xy.yml
@@ -69,8 +69,8 @@ jobs:
         - `type: area` with `mode: stacked` (default), `unstacked`, `percentage`
 
         ### Dimension types (`dimension:` and `breakdown:`)
-        - `type: values` — top values/terms with `field`, `size`, `other_bucket`,
-          `missing_bucket`, `include`/`exclude` (regex support), `collapse`
+        - `type: values` — top values/terms with `field`, `size`, `show_other_bucket`,
+          `include_missing_values`, `include`/`exclude` (regex support), `collapse`
         - `type: date_histogram` — with `field`, `minimum_interval`,
           `partial_intervals`
         - `type: intervals` — numeric ranges with `granularity`, `empty_bucket`


### PR DESCRIPTION
Summary:\n- reran full explore workflow audit on current main\n- fixed stale or deprecated schema key references in explore prompts\n- aligned prompts to canonical 0.4.0 keys\n\nValidation:\n- all explore workflow YAML files parse successfully\n- stale key reference audit reports zero issues\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration parameter names across ES|QL and Lens visualization workflows for improved consistency and clarity.
  * Restructured grid configuration keys for heatmap visibility toggles.
  * Reorganized metric and partition appearance settings under new namespaced structures.
  * Renamed values dimension options from `other_bucket` and `missing_bucket` to `show_other_bucket` and `include_missing_values` for enhanced intuitiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->