### PR TITLE
fix(audit): capture full decompile output to preserve error messages

### DIFF
--- a/.github/workflows/audit-integrations-decompile.yml
+++ b/.github/workflows/audit-integrations-decompile.yml
@@ -31,13 +31,14 @@ jobs:
           total=$((total + 1))
           rel="${f#integrations/}"
           out=".audit/decompile/output/$(basename "$f" .json).yaml"
-          if uv run kb-dashboard decompile "$f" -o "$out" 2>/dev/null; then
+          if output=$(uv run kb-dashboard decompile "$f" -o "$out" 2>&1); then
             successes=$((successes + 1))
           else
             failures=$((failures + 1))
-            errmsg=$(uv run kb-dashboard decompile "$f" -o "$out" 2>&1 | tail -1 || true)
+            errmsg=$(printf '%s\n' "$output" | grep -v '^[[:space:]]*$' | tail -1 || true)
+            [ -z "$errmsg" ] && errmsg="UNKNOWN_ERROR_NO_MESSAGE (exit code non-zero, no output)"
             echo "FAIL: $rel -- $errmsg" >> .audit/decompile/errors.log
-            echo "\"$rel\",\"$errmsg\"" >> .audit/decompile/failures.csv
+            printf '%s,"%s"\n' "\"$rel\"" "$errmsg" >> .audit/decompile/failures.csv
           fi
         done
 


### PR DESCRIPTION
## Summary
- Replace `tail -1` error capture with full output capture, filtering blank lines via `grep -v '^[[:space:]]*$'`
- Run each failing dashboard only once (previously re-ran it to capture the error message)
- Add sentinel `UNKNOWN_ERROR_NO_MESSAGE` when output is genuinely empty

## Why
All 132 failures in the fuzz audit (#1541) had empty error messages because the CLI ends output with a blank line and `tail -1` captured that blank line instead of the actual error.

## Test plan
- [ ] Trigger `workflow_dispatch` on the audit workflow and verify `failures.csv` contains real error messages
- [ ] Confirm blank-message rows no longer appear

Closes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal error handling and reporting in the audit workflow to better capture and log diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->