### PR TITLE
fix(workflows): correct invalid field names in explore agent prompts

### DIFF
--- a/.github/workflows/explore-esql-datatable.yml
+++ b/.github/workflows/explore-esql-datatable.yml
@@ -56,6 +56,11 @@ jobs:
         compile them, import into Kibana, and verify every setting renders correctly.
         Data views: `logs-*`, `metrics-*`.
 
+        ## Complete field reference
+        Read `packages/kb-dashboard-docs/content/panels/datatable.md` for the
+        full, always-current field reference and examples. This is the authoritative
+        source — the inline notes below are a summary only.
+
         ## ES|QL query configuration
         Queries can be specified as:
         - A single string or list of strings (joined with pipes)
@@ -87,8 +92,8 @@ jobs:
         - `appearance.color` — cell/text coloring:
           - `apply_to` — `none`, `cell`, `text`
           - `range_type` — `number` or `percent`
-          - `range_min`, `range_max`, `continuity`
-          - `stops` — color range `[{stop, color}]`
+          - `range_min`, `range_max`
+          - `thresholds` — color range `[{up_to, color}]`
 
         ### Table layout (`appearance:`)
         - `row_height` — `auto`, `single`, `custom`

--- a/.github/workflows/explore-esql-gauge.yml
+++ b/.github/workflows/explore-esql-gauge.yml
@@ -56,6 +56,11 @@ jobs:
         compile them, import into Kibana, and verify every setting renders correctly.
         Data views: `logs-*`, `metrics-*`.
 
+        ## Complete field reference
+        Read `packages/kb-dashboard-docs/content/panels/gauge.md` for the
+        full, always-current field reference and examples. This is the authoritative
+        source — the inline notes below are a summary only.
+
         ## ES|QL query configuration
         Queries can be specified as:
         - A single string: `query: "FROM logs-* | STATS count = COUNT()"`
@@ -92,12 +97,10 @@ jobs:
         - `ticks_position` — `auto`, `bands`, `hidden`
         - `labels` — show/hide value labels
 
-        ### Color palette (`color:`)
-        - `palette` — color palette for gauge bands
+        ### Color (`color:`)
         - `range_type` — `number` or `percent`
-        - `range_min`, `range_max` — band boundaries
-        - `continuity` — `above`, `below`, `all`, `none`
-        - `stops` — list of `{stop, color}` for band thresholds
+        - `range_min`, `range_max` — band boundaries (null for open)
+        - `thresholds` — list of `{up_to, color}` for band coloring (ascending order)
 
         ### Titles and text (`titles_and_text:`)
         - `subtitle` — text below the gauge title

--- a/.github/workflows/explore-esql-metric.yml
+++ b/.github/workflows/explore-esql-metric.yml
@@ -56,6 +56,11 @@ jobs:
         compile them, import into Kibana, and verify every setting renders correctly.
         Data views: `logs-*`, `metrics-*`.
 
+        ## Complete field reference
+        Read `packages/kb-dashboard-docs/content/panels/metric.md` for the
+        full, always-current field reference and examples. This is the authoritative
+        source — the inline notes below are a summary only.
+
         ## ES|QL query configuration
         Queries can be specified as:
         - A single string: `query: "FROM logs-* | STATS count = COUNT()"`
@@ -87,11 +92,10 @@ jobs:
         - `primary.font_size` — `default`, `xs`, `s`, `m`, `l`, `xl`, `xxl`
 
         ### Color (`color:`)
-        - `palette` — categorical or range color palette
+        - `apply_to` — `value` or `background` (default: `background`)
         - `range_type` — `number` or `percent`
         - `range_min`, `range_max` — custom range bounds
-        - `continuity` — `above`, `below`, `all`, `none`
-        - `stops` — list of `{stop, color}` for threshold coloring
+        - `thresholds` — list of `{up_to, color}` for threshold coloring
 
         ### Titles and text (`titles_and_text:`)
         - `prefix` — text before the value

--- a/.github/workflows/explore-lens-datatable.yml
+++ b/.github/workflows/explore-lens-datatable.yml
@@ -56,6 +56,11 @@ jobs:
         compile them, import into Kibana, and verify every setting renders correctly.
         Data views: `logs-*`, `metrics-*`.
 
+        ## Complete field reference
+        Read `packages/kb-dashboard-docs/content/panels/datatable.md` for the
+        full, always-current field reference and examples. This is the authoritative
+        source — the inline notes below are a summary only.
+
         ## Compiler-supported features to test
 
         ### Config slots
@@ -75,8 +80,8 @@ jobs:
         - `appearance.color` — cell/text coloring:
           - `apply_to` — `none`, `cell`, `text`
           - `range_type` — `number` or `percent`
-          - `range_min`, `range_max`, `continuity`
-          - `stops` — color range `[{stop, color}]`
+          - `range_min`, `range_max`
+          - `thresholds` — color range `[{up_to, color}]`
 
         ### Table layout (`appearance:`)
         - `row_height` — `auto`, `single`, `custom`

--- a/.github/workflows/explore-lens-gauge.yml
+++ b/.github/workflows/explore-lens-gauge.yml
@@ -57,6 +57,11 @@ jobs:
         correctly.
         Data views: `logs-*`, `metrics-*`.
 
+        ## Complete field reference
+        Read `packages/kb-dashboard-docs/content/panels/gauge.md` for the
+        full, always-current field reference and examples. This is the authoritative
+        source — the inline notes below are a summary only.
+
         ## Compiler-supported features to test
 
         ### Config slots (Kibana editor drop zones)
@@ -72,21 +77,20 @@ jobs:
         - `circle` — full circle
         - `semi_circle` — half circle
 
-        ### Titles and text
-        - `label_major` — main title text (maps to Kibana Title: Auto/Custom/None)
-        - `label_minor` — subtitle text (maps to Kibana Subtitle: Custom/None)
+        ### Titles and text (`titles_and_text:`)
+        - `title` — main title: string for custom text, `false` to hide, omit for auto
+        - `subtitle` — subtitle: string for custom text, omit to hide
 
         ### Tick marks (`appearance.ticks_position`)
         - `auto` — Kibana default
         - `bands` — show at color band boundaries
         - `hidden` — no tick marks
 
-        ### Color palette (`appearance.palette`)
-        Color range-based mapping for gauge bands:
+        ### Color (`color:`)
+        Range-based color mapping for gauge bands. Top-level field, not under `appearance`:
         - `range_type` — `number` or `percent`
         - `range_min`, `range_max` — bounds (null for open)
-        - `continuity` — `above`, `below`, `all`, `none`
-        - `stops` — list of `{stop, color}` objects (must be ascending)
+        - `thresholds` — list of `{up_to, color}` objects (must be ascending)
 
         ### Metric aggregation types
         All standard aggregations: `count`, `sum`, `average`, `min`, `max`,
@@ -105,7 +109,7 @@ jobs:
         - Semi-circle with formula metric `average(field='cpu.pct') * 100`
         - Gauge with static minimum=0, static maximum=100, dynamic goal
         - All 5 shapes side-by-side on one dashboard
-        - Color bands with `continuity: none` vs `continuity: all`
+        - Color bands with 2 thresholds (green/yellow/red) using `thresholds: [{up_to, color}]`
 
         ## Issue title
         The workflow automatically prefixes your title. Just provide the

--- a/.github/workflows/explore-lens-pie.yml
+++ b/.github/workflows/explore-lens-pie.yml
@@ -56,6 +56,11 @@ jobs:
         compile them, import into Kibana, and verify every setting renders correctly.
         Data views: `logs-*`, `metrics-*`.
 
+        ## Complete field reference
+        Read `packages/kb-dashboard-docs/content/panels/pie.md` for the
+        full, always-current field reference and examples. This is the authoritative
+        source — the inline notes below are a summary only.
+
         ## Compiler-supported features to test
 
         ### Config slots (Kibana editor drop zones)
@@ -80,8 +85,8 @@ jobs:
         `standard_deviation`, `formula`
 
         ### Slice labels and values (`appearance:`)
-        - `appearance.categories` — `hide`, `inside`, `auto` (default: auto)
-        - `appearance.values.visible` — `hide`, `integer`, `percent` (default: percent)
+        - `appearance.categories.position` — `hide`, `inside`, `auto` (default: auto)
+        - `appearance.values.format` — `hide`, `integer`, `percent` (default: percent)
         - `appearance.values.decimal_places` — 0-10 (default: 2)
 
         ### Legend (`legend:`)
@@ -100,7 +105,7 @@ jobs:
         After covering the feature matrix, try interesting combinations:
         - Donut with 2 nested ring breakdowns + custom color assignments
         - Pie with filters breakdown (e.g. error vs warning vs info)
-        - Large donut with `slice_labels: inside` + `slice_values: percent`
+        - Large donut with `appearance.categories.position: inside` + `appearance.values.format: percent`
         - Pie with `show_other_bucket: true` + small `size` to show grouping
         - Multiple metrics on a single pie (test emptySizeRatio behavior)
         - Formula-based metric as pie slice size


### PR DESCRIPTION
## Summary

- **Fixed invalid field names** in 6 explore workflow prompts that would cause agents to author uncompilable YAML configs
- **Added authoritative docs references** — each workflow now points agents at the local `packages/kb-dashboard-docs/content/panels/<chart>.md` file

### Per-workflow fixes

**`explore-lens-gauge.yml`**
- Fixed `color:` section header: was `appearance.palette` (wrong nesting), now correctly `color:` (top-level field)
- Removed invalid `continuity` field (doesn't exist in the model)
- Fixed `stops: [{stop, color}]` → `thresholds: [{up_to, color}]`
- Fixed gauge title fields: `label_major`/`label_minor` → `titles_and_text.title`/`titles_and_text.subtitle`
- Fixed creative exploration example: replaced `continuity: none vs all` with correct threshold example

**`explore-lens-pie.yml`**
- Fixed `appearance.categories` → `appearance.categories.position`
- Fixed `appearance.values.visible` → `appearance.values.format`
- Fixed creative exploration: corrected `slice_labels: inside` + `slice_values: percent` to proper field paths

**`explore-esql-gauge.yml`**
- Removed invalid `palette` and `continuity` fields
- Fixed `stops: [{stop, color}]` → `thresholds: [{up_to, color}]`

**`explore-lens-datatable.yml`** and **`explore-esql-datatable.yml`**
- Removed `continuity` field
- Fixed `stops` → `thresholds: [{up_to, color}]`

**`explore-esql-metric.yml`**
- Removed invalid `palette` and `continuity` fields
- Fixed `stops: [{stop, color}]` → `thresholds: [{up_to, color}]`

## Test plan
- [ ] Verify each workflow's field reference section matches what `ColorRangeMapping` / `ColorThreshold` models actually accept
- [ ] Spot-check that the local docs file paths resolve correctly in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for ES|QL and Lens visualization configurations (datatable, gauge, metric, and pie charts).
  * Added consolidated field reference guides for each visualization type.
  * Revised color and threshold configuration specifications across multiple visualization types.
  * Updated field names in configuration examples for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->