### PR TITLE
fix(workflows): space out explorers and unify concurrency

### DIFF
--- a/.github/workflows/explore-all.yml
+++ b/.github/workflows/explore-all.yml
@@ -14,8 +14,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Metric
         run: gh workflow run explore-lens-metric.yml
@@ -23,8 +23,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Gauge
         run: gh workflow run explore-lens-gauge.yml
@@ -32,8 +32,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Pie
         run: gh workflow run explore-lens-pie.yml
@@ -41,8 +41,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Partition (waffle, mosaic)
         run: gh workflow run explore-lens-partition.yml
@@ -50,8 +50,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Datatable
         run: gh workflow run explore-lens-datatable.yml
@@ -59,8 +59,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Heatmap
         run: gh workflow run explore-lens-heatmap.yml
@@ -68,8 +68,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Lens Tag Cloud
         run: gh workflow run explore-lens-tagcloud.yml
@@ -77,8 +77,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL XY (bar, line, area)
         run: gh workflow run explore-esql-xy.yml
@@ -86,8 +86,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Metric
         run: gh workflow run explore-esql-metric.yml
@@ -95,8 +95,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Gauge
         run: gh workflow run explore-esql-gauge.yml
@@ -104,8 +104,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Pie/Donut
         run: gh workflow run explore-esql-pie.yml
@@ -113,8 +113,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Partition (waffle, mosaic)
         run: gh workflow run explore-esql-partition.yml
@@ -122,8 +122,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Datatable
         run: gh workflow run explore-esql-datatable.yml
@@ -131,8 +131,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Heatmap
         run: gh workflow run explore-esql-heatmap.yml
@@ -140,8 +140,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger ES|QL Tag Cloud
         run: gh workflow run explore-esql-tagcloud.yml
@@ -149,8 +149,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
 
-      - name: Wait 5 minutes
-        run: sleep 300
+      - name: Wait 15 minutes
+        run: sleep 900
 
       - name: Trigger Content Panels (markdown, search, links, image, vega, section)
         run: gh workflow run explore-content-panels.yml

--- a/.github/workflows/explore-content-panels.yml
+++ b/.github/workflows/explore-content-panels.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-content-panels-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-datatable.yml
+++ b/.github/workflows/explore-esql-datatable.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-datatable-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-gauge.yml
+++ b/.github/workflows/explore-esql-gauge.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-gauge-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-heatmap.yml
+++ b/.github/workflows/explore-esql-heatmap.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-heatmap-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-metric.yml
+++ b/.github/workflows/explore-esql-metric.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-metric-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-partition.yml
+++ b/.github/workflows/explore-esql-partition.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-partition-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-pie.yml
+++ b/.github/workflows/explore-esql-pie.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-pie-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-tagcloud.yml
+++ b/.github/workflows/explore-esql-tagcloud.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-tagcloud-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-esql-xy.yml
+++ b/.github/workflows/explore-esql-xy.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-esql-xy-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-kibana-saved-objects-8.yml
+++ b/.github/workflows/explore-kibana-saved-objects-8.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
   id-token: write
 concurrency:
-  group: explore-kibana-saved-objects-8-${{ github.event.issue.number }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   run:

--- a/.github/workflows/explore-kibana-saved-objects.yml
+++ b/.github/workflows/explore-kibana-saved-objects.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
   id-token: write
 concurrency:
-  group: explore-kibana-saved-objects-${{ github.event.issue.number }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   run:

--- a/.github/workflows/explore-lens-datatable.yml
+++ b/.github/workflows/explore-lens-datatable.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-datatable-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-gauge.yml
+++ b/.github/workflows/explore-lens-gauge.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-gauge-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-heatmap.yml
+++ b/.github/workflows/explore-lens-heatmap.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-heatmap-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-metric.yml
+++ b/.github/workflows/explore-lens-metric.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-metric-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-partition.yml
+++ b/.github/workflows/explore-lens-partition.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-partition-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-pie.yml
+++ b/.github/workflows/explore-lens-pie.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-pie-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-tagcloud.yml
+++ b/.github/workflows/explore-lens-tagcloud.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-tagcloud-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-lens-xy.yml
+++ b/.github/workflows/explore-lens-xy.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
   pull-requests: read
 concurrency:
-  group: explore-lens-xy-${{ github.ref }}
+  group: explore-workflows-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   generate-matrix:

--- a/.github/workflows/explore-workflow-drift.yml
+++ b/.github/workflows/explore-workflow-drift.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+concurrency:
+  group: explore-workflows-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main

--- a/.github/workflows/explore-workflow-health.yml
+++ b/.github/workflows/explore-workflow-health.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+concurrency:
+  group: explore-workflows-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main


### PR DESCRIPTION
Addresses #1564 by increasing the delay between explorer triggers to 15 minutes and unifying the concurrency group across all explorers to ensure sequential execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized workflow concurrency grouping across automated pipelines to improve run management.
  * Extended wait times between workflow steps for improved execution timing.
  * Added concurrency control configuration to additional workflows for better scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->