### PR TITLE
fix(decompile): add per-function validation to infer functions

### DIFF
--- a/packages/kb-dashboard-tools/src/kb_dashboard_tools/decompile/infer.py
+++ b/packages/kb-dashboard-tools/src/kb_dashboard_tools/decompile/infer.py
@@ -11,7 +11,10 @@ Chart-specific logic is delegated to sub-modules:
 import logging
 from typing import Any
 
+from kb_dashboard_core.controls.config import ControlTypes
 from kb_dashboard_core.dashboard.config import Dashboard
+from kb_dashboard_core.filters.config import FilterTypes
+from pydantic import TypeAdapter, ValidationError
 
 from .infer_lens import _infer_lens_chart  # pyright: ignore[reportPrivateUsage]
 from .infer_simple import _SIMPLE_PANEL_BUILDERS  # pyright: ignore[reportPrivateUsage]
@@ -32,6 +35,9 @@ from .tables import (
 )
 
 logger = logging.getLogger(__name__)
+
+_filter_adapter: TypeAdapter[FilterTypes] = TypeAdapter(FilterTypes)
+_control_adapter: TypeAdapter[ControlTypes] = TypeAdapter(ControlTypes)
 
 # ---------------------------------------------------------------------------
 # Dashboard-level inference
@@ -115,6 +121,7 @@ def _infer_filter(pf: ParsedFilter) -> dict[str, Any] | None:
     if alias is not None and len(alias) > 0:
         f['alias'] = alias
 
+    _ = _filter_adapter.validate_python(f)
     return f
 
 
@@ -135,6 +142,7 @@ def _infer_control(pc: ParsedControl) -> dict[str, Any]:
         ctrl['data_view'] = pc.data_view_id if pc.data_view_id is not None else 'TODO_data_view'
     elif pc.data_view_id is not None:
         ctrl['data_view'] = pc.data_view_id
+    _ = _control_adapter.validate_python(ctrl)
     return ctrl
 
 
@@ -176,7 +184,11 @@ def _infer_panel(panel: ParsedPanel, ref_lookup: dict[str, str]) -> tuple[str, d
 
     # Lens/ESQL panel
     if panel.lens is not None:
-        chart = _infer_lens_chart(panel.lens)
+        try:
+            chart = _infer_lens_chart(panel.lens)
+        except (ValueError, ValidationError) as exc:
+            logger.warning('_infer_lens_chart validation failed for panel %s: %s', wrapper.get('id'), exc)
+            return 'markdown', {'content': f'TODO(decompile): panel validation failed: {exc}'}, wrapper
         return panel.lens.panel_type, chart, wrapper
 
     # Simple panels
@@ -215,13 +227,26 @@ def infer_dashboard(parsed: ParsedDashboard) -> tuple[Dashboard, list[dict[str, 
         dashboard['time_range'] = time_range
 
     if parsed.filters:
-        inferred_filters = [_infer_filter(f) for f in parsed.filters]
-        valid_filters = [f for f in inferred_filters if f is not None]
-        if valid_filters:
-            dashboard['filters'] = valid_filters
+        filters: list[dict[str, Any]] = []
+        for pf in parsed.filters:
+            try:
+                result = _infer_filter(pf)
+                if result is not None:
+                    filters.append(result)
+            except ValidationError as exc:
+                logger.warning('_infer_filter produced invalid filter dict (key=%s): %s', pf.key, exc)
+        if filters:
+            dashboard['filters'] = filters
 
     if parsed.controls:
-        dashboard['controls'] = [_infer_control(c) for c in parsed.controls]
+        controls: list[dict[str, Any]] = []
+        for pc in parsed.controls:
+            try:
+                controls.append(_infer_control(pc))
+            except ValidationError as exc:
+                logger.warning('_infer_control produced invalid control dict (type=%s): %s', pc.control_type, exc)
+        if controls:
+            dashboard['controls'] = controls
 
     if parsed.query is not None:
         dashboard['query'] = parsed.query

--- a/packages/kb-dashboard-tools/src/kb_dashboard_tools/decompile/infer_lens.py
+++ b/packages/kb-dashboard-tools/src/kb_dashboard_tools/decompile/infer_lens.py
@@ -5,8 +5,12 @@ panels — resolving chart types, extracting metrics/dimensions/breakdowns,
 legend settings, axis configuration, and appearance options.
 """
 
+import logging
 import re
 from typing import Any
+
+from kb_dashboard_core.panels.charts.config import ESQLPanelConfig, LensPanelConfig
+from pydantic import TypeAdapter, ValidationError
 
 from .parse import (
     ParsedColumn,
@@ -48,6 +52,11 @@ from .tables import (
 )
 
 __all__ = ['_infer_lens_chart']
+
+logger = logging.getLogger(__name__)
+
+_lens_panel_adapter: TypeAdapter[LensPanelConfig] = TypeAdapter(LensPanelConfig)
+_esql_panel_adapter: TypeAdapter[ESQLPanelConfig] = TypeAdapter(ESQLPanelConfig)
 
 # Chart-type classification sets (reused across functions)
 _XY_CHART_TYPES = frozenset({'line', 'bar', 'area'})
@@ -874,5 +883,11 @@ def _infer_lens_chart(parsed: ParsedLensPanel) -> dict[str, Any]:
 
     _assign_metrics_and_dimensions(chart, chart_type, all_metrics, all_dimensions, all_breakdowns)
     _fill_required_defaults(chart, chart_type, parsed.panel_type, has_skipped_metrics)
+
+    try:
+        _ = _lens_panel_adapter.validate_python(chart) if parsed.panel_type == 'lens' else _esql_panel_adapter.validate_python(chart)
+    except ValidationError as exc:
+        msg = f'infer_lens_chart produced invalid chart dict (type={chart_type}): {exc}'
+        raise ValueError(msg) from exc
 
     return chart


### PR DESCRIPTION
## Summary

- `_infer_lens_chart` now validates its output dict against `LensPanelConfig`/`ESQLPanelConfig` TypeAdapters before returning — on failure raises `ValueError` so `_infer_panel` can catch it and emit a markdown TODO panel instead of letting the whole dashboard fail at `Dashboard.model_validate()`
- `_infer_filter` and `_infer_control` validate their output dicts against `FilterTypes`/`ControlTypes` TypeAdapters before returning
- `_infer_panel` catches `ValueError`/`ValidationError` from `_infer_lens_chart` and degrades to a markdown fallback panel
- `infer_dashboard` wraps per-filter and per-control inference in try/except, skipping bad entries with a warning log rather than failing the whole dashboard

This closes the drift gap identified in #1559: schema violations (extra forbidden fields, invalid enums, wrong shapes) now surface at the function that produced them rather than silently accumulating until the final `Dashboard.model_validate()`.

## Test plan

- [x] `just tools ci` passes (159 tests)
- [x] `just all ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in dashboard parsing for improved robustness.
  * Invalid dashboard elements and configurations are now handled gracefully, skipping problematic items instead of interrupting the full decompilation process.

* **Refactor**
  * Internal validation improvements for more reliable dashboard decompilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->