### PR TITLE
fix: remove incorrect namespace prefix from search panel ref name

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/search/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/search/compile.py
@@ -19,7 +19,6 @@ def compile_search_panel_config(panel: SearchPanel, panel_index: str) -> tuple[l
 
     """
     panel_ref_name = f'panel_{panel_index}'
-    namespaced_panel_ref_name = f'{panel_index}:{panel_ref_name}'
     references: list[KbnReference] = [
         KbnReference(
             name=panel_ref_name,
@@ -34,4 +33,4 @@ def compile_search_panel_config(panel: SearchPanel, panel_index: str) -> tuple[l
         savedObjectId=panel.search.saved_search_id,
     )
 
-    return references, embeddable_config, namespaced_panel_ref_name
+    return references, embeddable_config, panel_ref_name


### PR DESCRIPTION
Fixes #1626

The search panel compiler wrapped the reference name as `{panel_index}:{panel_ref_name}`, but Kibana expects the plain `panel_ref_name`. This caused 'Missing data view' errors at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated panel reference naming format to remove namespace prefixes, resulting in simplified and more straightforward panel-level reference identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->