### PR TITLE
fix: add overall_avg alias for overall_average in formula parser

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/metrics/formula_parser.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/metrics/formula_parser.py
@@ -168,6 +168,7 @@ KIBANA_AGGREGATIONS = KIBANA_FIELD_AGGREGATIONS | KIBANA_FULL_REFERENCE_OPERATIO
 FORMULA_TO_OPERATION_TYPE = {
     'average': 'average',
     'avg': 'average',
+    'overall_avg': 'overall_average',
     'count': 'count',
     'counter_rate': 'counter_rate',
     'cumulative_sum': 'cumulative_sum',


### PR DESCRIPTION
Fixes #1639

The formula parser accepted `overall_average` but not the common shorthand `overall_avg`, causing formulas using `overall_avg()` to fail at runtime in Kibana. Added the alias mapping in `FORMULA_TO_OPERATION_TYPE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `overall_avg` formula function in chart metrics, enabling users to calculate overall averages in their dashboard visualizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strawgate/kb-yaml-to-lens/pull/1649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->