### PR TITLE
fix: add star_filled to reference line icon enum

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/xy/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/xy/compile.py
@@ -74,6 +74,7 @@ REFERENCE_LINE_ICONS_TO_KIBANA: dict[ReferenceLineIcon, KbnReferenceLineIcon] = 
     'map_marker': 'mapMarker',
     'pin_filled': 'pinFilled',
     'star_empty': 'starEmpty',
+    'star_filled': 'starFilled',
     'tag': 'tag',
     'triangle': 'triangle',
 }

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/xy/config.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/xy/config.py
@@ -23,6 +23,7 @@ type ReferenceLineIcon = Literal[
     'map_marker',
     'pin_filled',
     'star_empty',
+    'star_filled',
     'tag',
     'triangle',
 ]

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/xy/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/xy/view.py
@@ -28,6 +28,7 @@ type KbnReferenceLineIcon = Literal[
     'mapMarker',
     'pinFilled',
     'starEmpty',
+    'starFilled',
     'tag',
     'triangle',
 ]


### PR DESCRIPTION
Fixes #1638

Added `star_filled` to the config enum (`ReferenceLineIcon`), view model (`KbnReferenceLineIcon` as `starFilled`), and the compile mapping (`REFERENCE_LINE_ICONS_TO_KIBANA`).