### PR TITLE
feat: add from_unit option to duration format

### DIFF
--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/columns/view.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/columns/view.py
@@ -46,6 +46,9 @@ class KbnLensMetricFormatParams(BaseVwModel):
     pattern: Annotated[str | None, OmitIfNone()] = Field(default=None)
     """The pattern to display the number in."""
 
+    fromUnit: Annotated[str | None, OmitIfNone()] = Field(default=None)
+    """Input unit for duration formatting (nanoseconds, microseconds, milliseconds, seconds)."""
+
 
 class KbnLensMetricFormat(BaseVwModel):
     """The format of the column."""

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/metrics/compile.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/metrics/compile.py
@@ -465,6 +465,7 @@ def compile_lens_metric_format(metric_format: LensMetricFormatTypes) -> KbnLensM
                 decimals=decimals,
                 suffix=metric_format.suffix,
                 compact=metric_format.compact,
+                fromUnit=metric_format.from_unit,
             ),
         )
 

--- a/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/metrics/config.py
+++ b/packages/kb-dashboard-core/src/kb_dashboard_core/panels/charts/lens/metrics/config.py
@@ -59,6 +59,14 @@ class LensMetricFormat(BaseCfgModel):
     compact: bool | None = Field(default=None)
     """Whether to use compact notation (e.g., 1.2K instead of 1200). Defaults to Kibana's behavior."""
 
+    from_unit: Literal['nanoseconds', 'microseconds', 'milliseconds', 'seconds'] | None = Field(default=None)
+    """Input unit for duration formatting. Only valid when type is 'duration'.
+
+    Specifies the unit of the source field value so Kibana can convert it
+    to a human-readable duration. If not specified, Kibana defaults to
+    milliseconds. ECS fields like event.duration use nanoseconds.
+    """
+
 
 class LensCustomMetricFormat(BaseCfgModel):
     """Custom format configuration for metrics using numeral.js patterns.


### PR DESCRIPTION
Fixes #1644

Adds a `from_unit` field to `LensMetricFormat` that specifies the input unit for duration formatting. Kibana defaults to milliseconds, but ECS fields like `event.duration` use nanoseconds, causing wildly wrong display values (e.g., "5126 years" instead of "2.7 min").

## YAML usage

```yaml
format:
  type: duration
  from_unit: nanoseconds  # or microseconds, milliseconds, seconds
```

## Compiled output

```json
{"id": "duration", "params": {"decimals": 0, "fromUnit": "nanoseconds"}}
```

## Changes

- `config.py`: Added `from_unit` field to `LensMetricFormat` with Literal type validation
- `view.py`: Added `fromUnit` field to `KbnLensMetricFormatParams` (OmitIfNone)
- `compile.py`: Pass `from_unit` through to `fromUnit` in the compiled params

Backwards compatible — `from_unit` defaults to None, existing YAML without it produces the same output as before.

All 973 tests pass.